### PR TITLE
Remove -v1 from hajimari-config PVC claim

### DIFF
--- a/cluster/apps/default/hajimari/helm-release.yaml
+++ b/cluster/apps/default/hajimari/helm-release.yaml
@@ -115,7 +115,7 @@ spec:
     persistence:
       data:
         enabled: true
-        existingClaim: hajimari-config-v1
+        existingClaim: hajimari-config
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
**Description of the change**

The PVC seems to be created as `hajimari-config` but is being referenced as `hajimari-config-v1`

**Benefits**

Deploying will work

**Possible drawbacks**

None, except for my lack of knowledge with K8S and Helm

**Applicable issues**

N/A

**Additional information**

Before fix:
```
Events:
  Type     Reason            Age    From               Message
  ----     ------            ----   ----               -------
  Warning  FailedScheduling  4m51s  default-scheduler  0/3 nodes are available: 3 persistentvolumeclaim "hajimari-config-v1" not found.
  Warning  FailedScheduling  4m51s  default-scheduler  0/3 nodes are available: 3 persistentvolumeclaim "hajimari-config-v1" not found.
```

and

```
hajimari-config
Name:          hajimari-config
Namespace:     default
StorageClass:  local-path
Status:        Pending
Volume:
Labels:        kustomize.toolkit.fluxcd.io/name=apps
               kustomize.toolkit.fluxcd.io/namespace=flux-system
Annotations:   kustomize.toolkit.fluxcd.io/checksum: 88ecbf5e1268729664ae0ced2550d5d2237cdd2a
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:
Access Modes:
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                Age                  From                         Message
  ----    ------                ----                 ----                         -------
  Normal  WaitForFirstConsumer  51m (x3 over 51m)    persistentvolume-controller  waiting for first consumer to be created before binding
  Normal  WaitForFirstConsumer  37s (x202 over 50m)  persistentvolume-controller  waiting for first consumer to be created before binding
```

After change:
```
Name:          hajimari-config
Namespace:     default
StorageClass:  local-path
Status:        Bound
Volume:        pvc-4cd3f95e-369a-4f7f-be92-9323f66eac75
Labels:        kustomize.toolkit.fluxcd.io/name=apps
               kustomize.toolkit.fluxcd.io/namespace=flux-system
Annotations:   kustomize.toolkit.fluxcd.io/checksum: 45c1af07c5242a3ad110a95c0ecc59926d295364
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: rancher.io/local-path
               volume.kubernetes.io/selected-node: k3s-sub-1
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      128Mi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       hajimari-869b8f6fcb-rwl6c
Events:
  Type    Reason                 Age                    From                                                                                                Message
  ----    ------                 ----                   ----                                                                                                -------
  Normal  WaitForFirstConsumer   60m (x3 over 60m)      persistentvolume-controller                                                                         waiting for first consumer to be created before binding
  Normal  WaitForFirstConsumer   9m59s (x202 over 59m)  persistentvolume-controller                                                                         waiting for first consumer to be created before binding
  Normal  Provisioning           6m48s                  rancher.io/local-path_local-path-provisioner-5ff76fc89d-598xd_44fa863a-9d87-476a-980b-1dbf69e9059d  External provisioner is provisioning volume for claim "default/hajimari-config"
  Normal  ProvisioningSucceeded  6m43s                  rancher.io/local-path_local-path-provisioner-5ff76fc89d-598xd_44fa863a-9d87-476a-980b-1dbf69e9059d  Successfully provisioned volume pvc-4cd3f95e-369a-4f7f-be92-9323f66eac75
```