### PR TITLE
feat: Support talhelper NodeConfig additions

### DIFF
--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -49,6 +49,9 @@ nodes:
         vip:
           ip: "{{ cluster.endpoint_vip }}"
         {% endif %}
+    {% if item.talos_node_config %}
+    {{ item.talos_node_config | indent(4, false) }}
+    {% endif %}
   {% endfor %}
 
 controlPlane:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -32,6 +32,12 @@ cluster:
       #   controller: true       # (Required) Set to true if this is a controller node
       #   ssh_username: ""       # (Required: k3s/k0s) SSH username of the node
       #   talos_disk_device: ""  # (Required: Talos) Device Path or Serial number of Disk for this node
+      #   talos_node_config: |-  # (Optional: Talos) Additional NodeConfigs to apply to this node
+      #     schematic:           #  See: https://budimanjojo.github.io/talhelper/latest/reference/configuration/#nodeconfigs
+      #       customization:
+      #         systemExtensions:
+      #           officialExtensions:
+      #             - siderolabs/intel-ucode
       # ...
   # (Required) The pod CIDR for the cluster, this must NOT overlap with any
   #   existing networks and is usually a /16 (64K IPs).


### PR DESCRIPTION
This is the PR for https://github.com/onedr0p/cluster-template/discussions/1251#discussioncomment-8274805. This is to allow node-specific customizations for Talos to be retained when running `task configure` and `task talos:genconfig`. This also adds support to these tasks for installing Talos system extensions (See: https://github.com/onedr0p/cluster-template/issues/1248). 

For NodeConfig additions see: https://budimanjojo.github.io/talhelper/latest/reference/configuration/#nodeconfigs
For available system extensions: https://github.com/siderolabs/extensions

Example Usage (Adds Proxmox VM Guest Agent & CPU Microcode / GPU Pass-through support)
```
cluster:
  nodes:
    inventory:
      - name: "talos-a"
        address: "192.168.1.100"
        controller: true
        talos_disk_device: "/dev/sda"
        talos_node_config: &talosNodeConfigs |-
          schematic:
            customization:
              systemExtensions:
                officialExtensions:
                  - siderolabs/i915-ucode
                  - siderolabs/intel-ucode
                  - siderolabs/qemu-guest-agent
      - name: "talos-b"
        address: "192.168.1.101"
        controller: true
        talos_disk_device: "/dev/sda"
        talos_node_additions: *talosNodeAdditions
      - name: "talos-c"
        address: "192.168.1.102"
        controller: true
        talos_disk_device: "/dev/sda"
        talos_node_additions: *talosNodeAdditions

```