### PR TITLE
feat: Talos network vlan tagging

### DIFF
--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -35,6 +35,20 @@ nodes:
     networkInterfaces:
       - interface: eth0
         dhcp: false
+        {% if cluster.nodes.talos.vlan %}
+        vlans:
+          - vlanId: {{ cluster.nodes.talos.vlan }}
+            addresses:
+              - "{{ item.address }}/{{ cluster.nodes.host_network.split('/') | last }}"
+            mtu: 1500
+            routes:
+              - network: 0.0.0.0/0
+                gateway: "{{ cluster.nodes.host_network | nthhost(1) }}"
+            {% if item.controller %}
+            vip:
+              ip: "{{ cluster.endpoint_vip }}"
+            {% endif %}
+        {% else %}
         addresses:
           - "{{ item.address }}/{{ cluster.nodes.host_network.split('/') | last }}"
         mtu: 1500
@@ -44,6 +58,7 @@ nodes:
         {% if item.controller %}
         vip:
           ip: "{{ cluster.endpoint_vip }}"
+        {% endif %}
         {% endif %}
   {% endfor %}
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -51,6 +51,9 @@ cluster:
       #       officialExtensions:
       #         - siderolabs/intel-ucode
       #         - siderolabs/i915-ucode
+      # # (Optional) Add vlan tag to network master device
+      # #   See: https://www.talos.dev/latest/advanced/advanced-networking/#vlans
+      # vlan: 1
   # (Required) The pod CIDR for the cluster, this must NOT overlap with any
   #   existing networks and is usually a /16 (64K IPs).
   # If you want to use IPv6 check the advanced flags below


### PR DESCRIPTION
The `talconfig.yaml` can easily support vlan tagging by shifting it's network block indentation and adding a "vlanId" key. I added this under `cluster.nodes.talos.vlan` but suspect it could exist under `cluster.nodes.vlan` or similar if you need to add support for the other distributions.

Documentation: https://www.talos.dev/v1.6/advanced/advanced-networking/#vlans