### PR TITLE
feat: upgrade k3s to 1.29.1 and enable the spegel embedded registry

### DIFF
--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
@@ -10,3 +10,14 @@ k3s_server_manifests_templates:
   - kube-vip-ds.yaml
   - kube-vip-rbac.yaml
 k3s_use_unsupported_config: true
+k3s_registries:
+  mirrors:
+    docker.io:
+    gcr.io:
+    ghcr.io:
+    k8s.gcr.io:
+    lscr.io:
+    mcr.microsoft.com:
+    public.ecr.aws:
+    quay.io:
+    registry.k8s.io:

--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
@@ -3,13 +3,6 @@ k3s_become: true
 k3s_etcd_datastore: true
 k3s_install_hard_links: true
 k3s_registration_address: "{{ cluster.endpoint_vip }}"
-# renovate: datasource=github-releases depName=k3s-io/k3s
-k3s_release_version: v1.29.1+k3s1
-k3s_server_manifests_templates:
-  - custom-cilium-helmchart.yaml
-  - kube-vip-ds.yaml
-  - kube-vip-rbac.yaml
-k3s_use_unsupported_config: true
 k3s_registries:
   mirrors:
     docker.io:
@@ -21,3 +14,10 @@ k3s_registries:
     public.ecr.aws:
     quay.io:
     registry.k8s.io:
+# renovate: datasource=github-releases depName=k3s-io/k3s
+k3s_release_version: v1.29.1+k3s1
+k3s_server_manifests_templates:
+  - custom-cilium-helmchart.yaml
+  - kube-vip-ds.yaml
+  - kube-vip-rbac.yaml
+k3s_use_unsupported_config: true

--- a/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/kubernetes/main.yaml.j2
@@ -4,7 +4,7 @@ k3s_etcd_datastore: true
 k3s_install_hard_links: true
 k3s_registration_address: "{{ cluster.endpoint_vip }}"
 # renovate: datasource=github-releases depName=k3s-io/k3s
-k3s_release_version: v1.29.0+k3s1
+k3s_release_version: v1.29.1+k3s1
 k3s_server_manifests_templates:
   - custom-cilium-helmchart.yaml
   - kube-vip-ds.yaml

--- a/bootstrap/templates/ansible/inventory/group_vars/master/main.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/group_vars/master/main.yaml.j2
@@ -13,6 +13,7 @@ k3s_server:
   disable-kube-proxy: true
   disable-network-policy: true
   docker: false
+  embedded-registry: true
   etcd-expose-metrics: true
   flannel-backend: "none"
   kube-apiserver-arg:

--- a/bootstrap/templates/kubernetes/apps/system-upgrade/k3s/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/system-upgrade/k3s/ks.yaml.j2
@@ -23,4 +23,4 @@ spec:
   postBuild:
     substitute:
       # renovate: datasource=github-releases depName=k3s-io/k3s
-      KUBE_VERSION: v1.29.0+k3s1
+      KUBE_VERSION: v1.29.1+k3s1


### PR DESCRIPTION
- Updates k3s to 1.29.1
- Enables [Spegel embedded registry](https://docs.k3s.io/installation/registry-mirror)

Fixes https://github.com/onedr0p/cluster-template/issues/1049