### PR TITLE
fix(talos): Mount openebs-hostpath in kubelet

### DIFF
--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -183,6 +183,19 @@ controlPlane:
             allowedKubernetesNamespaces:
               - system-upgrade
 
+    # Mount openebs-hostpath in kubelet
+    - &openEbsPatch |-
+      machine:
+        kubelet:
+          extraMounts:
+            - destination: /var/openebs/local
+              type: bind
+              source: /var/openebs/local
+              options:
+                - bind
+                - rshared
+                - rw
+
 {% if nodes.inventory | selectattr('controller', 'equalto', False) | list | length %}
 worker:
 {% if distribution.talos.schematics.enabled %}
@@ -199,4 +212,5 @@ worker:
     - *nameserverPatch
     - *ntpPatch
     - *sysctlPatch
+    - *openEbsPatch
 {% endif %}


### PR DESCRIPTION
On talos the openebs-hostpath PVCs fail to mount due to "not found" errors. Talos [documentation](https://www.talos.dev/v1.6/kubernetes-guides/configuration/replicated-local-storage-with-openebs-jiva/#preparing-the-nodes) notes the "/var/openebs/local" path mounts point needs to be mounted in the kubelet to be accessible to kubernetes. The docs comment about OpenEBS Jiva for replicated storage, but the same still applies for our local hostpath implementation too. Once my talos nodes had this added, PVCs with storageClass `openebs-hostpath` succeeded to mount and be usable.