### PR TITLE
feat(talos): Add cilium bgpControlPlane support and CNI security settings

### DIFF
--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
@@ -5,10 +5,6 @@ kind: CiliumBGPPeeringPolicy
 metadata:
   name: policy
 spec:
-  loadBalancerIPs: true
-  # NOTE: This might need to be set if you have more than one active NIC on your hosts
-  # interfaces:
-  #   - ^eno[0-9]+
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
@@ -17,11 +13,11 @@ spec:
       neighbors:
         {% if distribution.talos.bgp.peers %}
         {% for item in distribution.talos.bgp.peers %}
-        - peerAddress: "{{ item }}"
+        - peerAddress: "{{ item }}/32"
           peerASN: {{ distribution.talos.bgp.peer_asn }}
         {% endfor %}
         {% else %}
-        - peerAddress: "{{ nodes.host_network | nthhost(1) }}"
+        - peerAddress: "{{ nodes.host_network | nthhost(1) }}/32"
           peerASN: {{ distribution.talos.bgp.peer_asn }}
         {% endif %}
 ---

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
@@ -1,0 +1,34 @@
+---
+# https://docs.cilium.io/en/latest/network/bgp-control-plane/
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeeringPolicy
+metadata:
+  name: policy
+spec:
+  loadBalancerIPs: true
+  # NOTE: This might need to be set if you have more than one active NIC on your hosts
+  # interfaces:
+  #   - ^eno[0-9]+
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  virtualRouters:
+    - localASN: {{ distribution.talos.bgp.local_asn }}
+      neighbors:
+        {% if distribution.talos.bgp.peers %}
+        {% for item in distribution.talos.bgp.peers %}
+        - peerAddress: "{{ item }}"
+          peerASN: {{ distribution.talos.bgp.peer_asn }}
+        {% endfor %}
+        {% else %}
+        - peerAddress: "{{ nodes.host_network | nthhost(1) }}"
+          peerASN: {{ distribution.talos.bgp.peer_asn }}
+        {% endif %}
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: pool
+spec:
+  cidrs:
+    - cidr: "${LOADBALANCER_CIDR}"

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-bgp.yaml.j2
@@ -20,6 +20,9 @@ spec:
         - peerAddress: "{{ nodes.host_network | nthhost(1) }}/32"
           peerASN: {{ distribution.talos.bgp.peer_asn }}
         {% endif %}
+      serviceSelector:
+        matchExpressions:
+          - {key: somekey, operator: NotIn, values: ['never-used-value']}
 ---
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
@@ -2,7 +2,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  {% if not feature_gates.dual_stack_ipv4_first %}
+  {% if distribution.talos.bgp.enabled %}
+  - ./cilium-bgp.yaml
+  {% endif %}
+  {% if ( (not distribution.talos.bgp.enabled) and
+          (feature_gates.dual_stack_ipv4_first) ) %}
   - ./cilium-l2.yaml
   {% endif %}
   - ./helmrelease.yaml

--- a/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/vars/cluster-settings.yaml.j2
@@ -11,3 +11,6 @@ data:
   {% if feature_gates.dual_stack_ipv4_first %}
   CLUSTER_CIDR_V6: "{{ cluster.pod_network.split(',')[1] }}"
   {% endif %}
+  {% if distribution.talos.bgp.enabled %}
+  LOADBALANCER_CIDR: "{{ distribution.talos.bgp.loadbalancer_network }}"
+  {% endif %}

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -1,4 +1,8 @@
 autoDirectNodeRoutes: true
+{% if distribution.talos.bgp.enabled %}
+bgpControlPlane:
+  enabled: true
+{% endif %}
 bpf:
   masquerade: true
 {% if distribution.type in ["talos"] %}
@@ -74,7 +78,8 @@ k8sServicePort: 7445
 kubeProxyReplacement: true
 kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
 l2announcements:
-  {% if feature_gates.dual_stack_ipv4_first %}
+  {% if ( (distribution.talos.bgp.enabled) or
+          (feature_gates.dual_stack_ipv4_first) ) %}
   # https://github.com/cilium/cilium/issues/28985
   enabled: false
   {% else %}

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -5,12 +5,10 @@ bgpControlPlane:
 {% endif %}
 bpf:
   masquerade: true
-{% if distribution.type in ["talos"] %}
 cgroup:
   automount:
     enabled: false
   hostRoot: /sys/fs/cgroup
-{% endif %}
 cluster:
   name: home-kubernetes
   id: 1

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -112,7 +112,6 @@ dashboards:
 rollOutCiliumPods: true
 routingMode: native
 securityContext:
-  {% if distribution.type in ["talos"] %}
   capabilities:
     ciliumAgent:
       - CHOWN
@@ -130,6 +129,3 @@ securityContext:
       - NET_ADMIN
       - SYS_ADMIN
       - SYS_RESOURCE
-  {% else %}
-  privileged: true
-  {% endif %}

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -1,6 +1,12 @@
 autoDirectNodeRoutes: true
 bpf:
   masquerade: true
+{% if distribution.type in ["talos"] %}
+cgroup:
+  automount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
+{% endif %}
 cluster:
   name: home-kubernetes
   id: 1
@@ -101,4 +107,24 @@ dashboards:
 rollOutCiliumPods: true
 routingMode: native
 securityContext:
+  {% if distribution.type in ["talos"] %}
+  capabilities:
+    ciliumAgent:
+      - CHOWN
+      - KILL
+      - NET_ADMIN
+      - NET_RAW
+      - IPC_LOCK
+      - SYS_ADMIN
+      - SYS_RESOURCE
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    cleanCiliumState:
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_RESOURCE
+  {% else %}
   privileged: true
+  {% endif %}

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -5,12 +5,10 @@ bgpControlPlane:
 {% endif %}
 bpf:
   masquerade: true
-{% if distribution.type in ["talos"] %}
 cgroup:
   automount:
     enabled: false
   hostRoot: /sys/fs/cgroup
-{% endif %}
 cluster:
   name: home-kubernetes
   id: 1

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -1,4 +1,8 @@
 autoDirectNodeRoutes: true
+{% if distribution.talos.bgp.enabled %}
+bgpControlPlane:
+  enabled: true
+{% endif %}
 bpf:
   masquerade: true
 {% if distribution.type in ["talos"] %}
@@ -37,7 +41,8 @@ k8sServicePort: 7445
 kubeProxyReplacement: true
 kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
 l2announcements:
-  {% if feature_gates.dual_stack_ipv4_first %}
+  {% if ( (distribution.talos.bgp.enabled) or
+          (feature_gates.dual_stack_ipv4_first) ) %}
   # https://github.com/cilium/cilium/issues/28985
   enabled: false
   {% else %}

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -1,6 +1,12 @@
 autoDirectNodeRoutes: true
 bpf:
   masquerade: true
+{% if distribution.type in ["talos"] %}
+cgroup:
+  automount:
+    enabled: false
+  hostRoot: /sys/fs/cgroup
+{% endif %}
 cluster:
   name: home-kubernetes
   id: 1
@@ -47,4 +53,24 @@ operator:
 rollOutCiliumPods: true
 routingMode: native
 securityContext:
+  {% if distribution.type in ["talos"] %}
+  capabilities:
+    ciliumAgent:
+      - CHOWN
+      - KILL
+      - NET_ADMIN
+      - NET_RAW
+      - IPC_LOCK
+      - SYS_ADMIN
+      - SYS_RESOURCE
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETGID
+      - SETUID
+    cleanCiliumState:
+      - NET_ADMIN
+      - SYS_ADMIN
+      - SYS_RESOURCE
+  {% else %}
   privileged: true
+  {% endif %}

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -58,7 +58,6 @@ operator:
 rollOutCiliumPods: true
 routingMode: native
 securityContext:
-  {% if distribution.type in ["talos"] %}
   capabilities:
     ciliumAgent:
       - CHOWN
@@ -76,6 +75,3 @@ securityContext:
       - NET_ADMIN
       - SYS_ADMIN
       - SYS_RESOURCE
-  {% else %}
-  privileged: true
-  {% endif %}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -28,6 +28,22 @@ distribution:
     # # (Optional) Add vlan tag to network master device
     # #   See: https://www.talos.dev/latest/advanced/advanced-networking/#vlans
     # vlan: 1
+    # # (Optional) Use cilium BGP control plane when L2 announcements won't traverse VLAN network segments.
+    # #   Needs a BGP capable router setup with the node IPs as peers.
+    # #   See: https://docs.cilium.io/en/latest/network/bgp-control-plane/
+    # bgp:
+    #   enabled: true
+    #   # (Optional) If using multiple BGP peers add them here.
+    #   #   Default is .1 derrived from host_network: ['x.x.x.1']
+    #   peers: []
+    #   # (Required) Set the BGP Autonomous System Number for the router(s) and nodes.
+    #   #  If these match, iBGP will be used. If not, eBGP will be used.
+    #   peer_asn: 64512   # Router(s) AS
+    #   local_asn: 64512  # Node(s) AS
+    #   # (Required) The loadbalancer CIDR for the cluster, this must NOT overlap with any
+    #   #   existing networks and is usually a /16 (64K IPs).
+    #   # If you want to use IPv6 check the advanced flags below
+    #   loadbalancer_network: 10.123.0.0/16
 
 #
 # (Required) Timezone is your IANA formatted timezone (e.g. America/New_York)


### PR DESCRIPTION
When using VLAN network separation, Cilium's L2 announcements may not traverse the L2 network segments. When this is the case, it can help to have Cilium switch to BGP control plane mode and handle advertising the LoadBalancer IPs via a router instead. This requires a router with BGP support such as pfSense with the FRR package installed (or similar).

In this PR I am re-using the existing `CiliumLoadBalancerIPPool` from cilium-l2.yaml named "pool". Since this switches from L2 announcements to BGP, their is no conflict and `multi-pool` IPAM is not required to support both simultaneously. The "LOADBALANCER_CIDR" cluster-wide var is used for tracking this. 

The bgp settings maybe movable in the future to outside the talos dict to be used by kube-vip if cilium CNI is not in use.

The `cilium-values-init` and `cilium-values-full` partials templates we're also not using some of the Talos required settings from their [Cilium CNI install guide](https://www.talos.dev/v1.6/kubernetes-guides/network/deploying-cilium/). These have been added when the talos distribution is set.

Example config.yaml
```
distribution: talos
  type: talos
  talos:
    vlan: 1
    bgp:
      enabled: true
      local_asn: 64512
      peer_asn: 64512
      peers:
        - 192.168.1.1
      loadbalancer_network: 10.123.0.0/16
```