### PR TITLE
Fix Talos SUC ServiceAccount

### DIFF
--- a/bootstrap/templates/kubernetes/apps/system-upgrade/system-upgrade-controller/app/rbac.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/system-upgrade/system-upgrade-controller/app/rbac.yaml.j2
@@ -19,5 +19,5 @@ metadata:
   name: talos
 spec:
   roles:
-    - os:operator
+    - os:admin
 {% endif %}

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -179,7 +179,7 @@ controlPlane:
           kubernetesTalosAPIAccess:
             enabled: true
             allowedRoles:
-              - os:operator
+              - os:admin
             allowedKubernetesNamespaces:
               - system-upgrade
 


### PR DESCRIPTION
Great work on adding SUC to this template. I've tested your code, but the health check errors out having to less permissions with `os:operator` right. Granting `os:admin` works for performing the health check and upgrade Talos to new versions automagicly. Tested from 1.6.2 to 1.6.4.