### PR TITLE
fix(bootstrap): patch flux resource names to match oci manifests

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/kustomization.yaml.j2
@@ -16,3 +16,46 @@ patches:
     target:
       group: networking.k8s.io
       kind: NetworkPolicy
+  # rename resources to match those installed by oci://ghcr.io/fluxcd/flux-manifests
+  - target:
+      kind: ResourceQuota
+      name: critical-pods
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: critical-pods-flux-system
+  - target:
+      kind: ClusterRoleBinding
+      name: cluster-reconciler
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: cluster-reconciler-flux-system
+  - target:
+      kind: ClusterRoleBinding
+      name: crd-controller
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: crd-controller-flux-system
+  - target:
+      kind: ClusterRole
+      name: crd-controller
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: crd-controller-flux-system
+  - target:
+      kind: ClusterRole
+      name: flux-edit
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: flux-edit-flux-system
+  - target:
+      kind: ClusterRole
+      name: flux-view
+    patch: |
+      - op: replace
+        path: /metadata/name
+        value: flux-view-flux-system

--- a/bootstrap/templates/kubernetes/bootstrap/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/kustomization.yaml.j2
@@ -16,7 +16,7 @@ patches:
     target:
       group: networking.k8s.io
       kind: NetworkPolicy
-  # rename resources to match those installed by oci://ghcr.io/fluxcd/flux-manifests
+  # Resources renamed to match those installed by oci://ghcr.io/fluxcd/flux-manifests
   - target:
       kind: ResourceQuota
       name: critical-pods


### PR DESCRIPTION
Resource names differ in the installation manifests installed by the install file found on the flux/fluxcd2 github repo and the oci artifact oci://ghcr.io/fluxcd/flux-manifests. This commit introduces patches to the bootstrap kustomization to rename the resources to match the oci manifests.