### PR TITLE
Talos: remove deprecated System Extentions and move to schematicID

### DIFF
--- a/.github/tests/config-talos.yaml
+++ b/.github/tests/config-talos.yaml
@@ -4,16 +4,7 @@ skip_tests: true
 distribution:
   type: talos
   talos:
-    schematics:
-      enabled: true
-      id: df491c50a5acc05b977ef00c32050e1ceb0df746e40b33c643ac8a9bfb7c7263
-      customization: |-
-        extraKernelArgs:
-          - net.ifnames=0
-        systemExtensions:
-          officialExtensions:
-            - siderolabs/intel-ucode
-            - siderolabs/i915-ucode
+    schematicID: "df491c50a5acc05b977ef00c32050e1ceb0df746e40b33c643ac8a9bfb7c7263"
 
 timezone: Etc/UTC
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ You have two different options for setting up your local workstation.
 
 #### Talos
 
-1. Create Talos Secrets
+1. Create Talos Secrets and configuration
 
     ```sh
     task talos:gensecret

--- a/bootstrap/templates/kubernetes/apps/system-upgrade/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/system-upgrade/kustomization.yaml.j2
@@ -9,6 +9,6 @@ resources:
   {% if distribution.type in ["k3s"] %}
   - ./k3s/ks.yaml
   {% endif %}
-  {% if distribution.type in ["talos"] and nodes.talos.schematics.enabled %}
+  {% if distribution.type in ["talos"] and distribution.talos.schematicID %}
   - ./talos/ks.yaml
   {% endif %}

--- a/bootstrap/templates/kubernetes/apps/system-upgrade/talos/.mjfilter.py
+++ b/bootstrap/templates/kubernetes/apps/system-upgrade/talos/.mjfilter.py
@@ -2,6 +2,5 @@ main = lambda data: (
     data.get("distribution", {}).get("type", "k3s") in ["talos"] and
         data.get("distribution", {})
             .get("talos", {})
-            .get("schematics", {})
-            .get("enabled", False) == True
+            .get("schematicID", {})
 )

--- a/bootstrap/templates/kubernetes/apps/system-upgrade/talos/app/plan.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/system-upgrade/talos/app/plan.yaml.j2
@@ -88,6 +88,6 @@ spec:
     args:
       - --nodes=$(NODE_IP)
       - upgrade
-      - --image=factory.talos.dev/installer/{{ distribution.talos.schematics.id }}:$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
+      - --image=factory.talos.dev/installer/{{ distribution.talos.schematicID }}:$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
       - --preserve=true
       - --wait=false

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -31,6 +31,7 @@ nodes:
     installDiskSelector:
       serial: "{{ item.talos_disk_device }}"
     {% endif %}
+    talosImageURL: factory.talos.dev/installer/{{ distribution.talos.schematicID }}
     controlPlane: {{ (item.controller) | string | lower }}
     networkInterfaces:
       - interface: eth0
@@ -63,11 +64,6 @@ nodes:
   {% endfor %}
 
 controlPlane:
-{% if distribution.talos.schematics.enabled %}
-  schematic:
-    customization:
-{{ distribution.talos.schematics.customization | indent(6, first=True) }}
-{% endif %}
   patches:
     # Configure containerd
     - &containerdPatch |-

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -9,22 +9,10 @@ distribution:
   type: k3s
   # (Optional) Talos Specific Options
   talos: {}
-    # schematics:
-    #   # (Required) Disabling the schematic will disable the system-upgrade-controller and any
-    #   #   additional Talos customization you have defined.
-    #   enabled: false
-    #   # (Required) For use with the system-upgrade-controller generate a schematic ID
-    #   #   based on your System Extension requirements https://factory.talos.dev/
-    #   id: ""
-    #   # (Required) Additional NodeConfigs to apply to all nodes
-    #   #   See: https://budimanjojo.github.io/talhelper/latest/reference/configuration/#nodeconfigs
-    #   customization: |-
-    #     extraKernelArgs:
-    #       - net.ifnames=0
-    #     systemExtensions:
-    #       officialExtensions:
-    #         - siderolabs/intel-ucode
-    #         - siderolabs/i915-ucode
+    # # (Required) If you need any additional System Extensions and/or kernel arguments generate a schematic ID.
+    # # Go to https:tas//factory.talos.dev/ and choose the System Extensions you need and/or add extra kernel arguments.
+    # # Otherwise use below default.
+    # schematicID: "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
     # # (Optional) Add vlan tag to network master device
     # #   See: https://www.talos.dev/latest/advanced/advanced-networking/#vlans
     # vlan: 1

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -10,7 +10,7 @@ distribution:
   # (Optional) Talos Specific Options
   talos: {}
     # # (Required) If you need any additional System Extensions and/or kernel arguments generate a schematic ID.
-    # # Go to https:tas//factory.talos.dev/ and choose the System Extensions you need and/or add extra kernel arguments.
+    # # Go to https://factory.talos.dev/ and choose the System Extensions you need and/or add extra kernel arguments.
     # # Otherwise use below default.
     # schematicID: "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
     # # (Optional) Add vlan tag to network master device


### PR DESCRIPTION
As discussed briefly on Discord.
Modified both talhelper and SUC config to use only SchematicID