### PR TITLE
fix(cilium): Correct L2 kustomization exclusion logic

### DIFF
--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
@@ -6,7 +6,7 @@ resources:
   - ./cilium-bgp.yaml
   {% endif %}
   {% if ( (not distribution.talos.bgp.enabled) and
-          (feature_gates.dual_stack_ipv4_first) ) %}
+          (not feature_gates.dual_stack_ipv4_first) ) %}
   - ./cilium-l2.yaml
   {% endif %}
   - ./helmrelease.yaml


### PR DESCRIPTION
In PR 1296 I accidentally [inversed ](https://github.com/Wasurerarenai/cluster-template/blob/a5761d67c35b9ccc90f1a2844d8fa25e53dcef1d/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2#L8-L10) the correct feature_gates.dual_stack_ipv4_first detection logic. This caused Talos distributions without BGPCP enabled to not include the cilium-l2.yaml file needed. This patch allows the cilium-l2.yaml inclusion to be generated when talos bgp or feature_gates.dual_stack_ipv4_first are disabled, and removed when either are present. 