### PR TITLE
feat(talos): Add secureboot & tpm-based disk encryption support

### DIFF
--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -31,7 +31,13 @@ nodes:
     installDiskSelector:
       serial: "{{ item.talos_disk_device }}"
     {% endif %}
+    {% if distribution.talos.secureboot.enabled %}
+    machineSpec:
+      secureboot: true
+    talosImageURL: factory.talos.dev/installer-secureboot/{{ distribution.talos.schematicID }}
+    {% else %}
     talosImageURL: factory.talos.dev/installer/{{ distribution.talos.schematicID }}
+    {% endif %}
     controlPlane: {{ (item.controller) | string | lower }}
     networkInterfaces:
       - interface: eth0
@@ -151,6 +157,24 @@ patches:
       install:
         extraKernelArgs:
           - net.ifnames=0
+
+  {% if distribution.talos.secureboot.enabled and
+        distribution.talos.secureboot.encrypt_disk_with_tpm %}
+  # Encrypt system disk with TPM
+  - |-
+    machine:
+      systemDiskEncryption:
+        ephemeral:
+          provider: luks2
+          keys:
+            - slot: 0
+              tpm: {}
+        state:
+          provider: luks2
+          keys:
+            - slot: 0
+              tpm: {}
+  {% endif %}
 
 controlPlane:
   patches:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -32,6 +32,13 @@ distribution:
     #   #   existing networks and is usually a /16 (64K IPs).
     #   # If you want to use IPv6 check the advanced flags below
     #   loadbalancer_network: 10.123.0.0/16
+    # secureboot:
+    #   # (Optional) Enable secureboot on UEFI systems. Not supported on x86 platforms in BIOS mode.
+    #   #   See: https://www.talos.dev/latest/talos-guides/install/bare-metal-platforms/secureboot
+    #   enabled: true
+    #   # (Optional) Enable TPM-based disk encryption. Requires TPM 2.0
+    #   #   See: https://www.talos.dev/v1.6/talos-guides/install/bare-metal-platforms/secureboot/#disk-encryption-with-tpm
+    #   encrypt_disk_with_tpm: true
 
 #
 # (Required) Timezone is your IANA formatted timezone (e.g. America/New_York)


### PR DESCRIPTION
I've added secureboot and system disk encryption support to the talos config block and talconfig template. Talhelper added support in [v2.2.0](https://github.com/budimanjojo/talhelper/commit/606f72f4f98eb7904c1905a67532211cad49a0c2). The [machineSpec](https://budimanjojo.github.io/talhelper/latest/reference/configuration/#machinespec) secureboot field usually modifies the talosImageURL by replacing "installer" with "installer-secureboot". I added this to the jinja template to keep with the support added for schematicID and SUC.

The  system disk can also be encrypted, sealed, and unsealed automatically via secure keys stored in the TPM 2.0 module. Talos gives us an example [here](https://www.talos.dev/v1.6/talos-guides/install/bare-metal-platforms/secureboot/#disk-encryption-with-tpm) which only needed a machine yaml patch. This aids in enhancing the security of Talos, one of the main reasons users choose the distribution.