### PR TITLE
Talos: One-liner deployment code

### DIFF
--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -14,7 +14,6 @@ tasks:
 
   gensecret:
     desc: Generate talos secret
-    prompt: This will overwrite the existing secret... continue?
     dir: "{{.TALOS_DIR}}"
     cmds:
       - talhelper gensecret > {{.TALHELPER_SECRET_FILE}}
@@ -23,6 +22,8 @@ tasks:
           file: "{{.TALHELPER_SECRET_FILE}}"
     preconditions:
       - { msg: "Missing talhelper config file", sh: "test -f {{.TALHELPER_CONFIG_FILE}}" }
+    status:
+      - test -f "{{.TALHELPER_SECRET_FILE}}"
 
   genconfig:
     desc: Generate talos config
@@ -47,11 +48,8 @@ tasks:
 
   kubeconfig:
     desc: Generate talos kubeconfig
-    prompt: This will overwrite the existing kubeconfig... continue?
     dir: "{{.TALOS_DIR}}"
-    cmd: talosctl --nodes {{.node}} kubeconfig {{.ROOT_DIR}} --force
-    requires:
-      vars: ["node"]
+    cmd: talhelper gencommand kubeconfig --extra-flags "--force" | bash
 
   apply-extras:
     desc: Apply extras
@@ -61,6 +59,38 @@ tasks:
       - kubectl --kubeconfig {{.KUBECONFIG_FILE}} kustomize --enable-helm ./kubelet-csr-approver | kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --filename -
     preconditions:
       - { msg: "Missing kubeconfig", sh: "test -f {{.KUBECONFIG_FILE}}" }
+
+  deploy:
+    desc: Deploys your Talos cluster in one command
+    dir: "{{.TALOS_DIR}}"
+    cmds:
+      - task: gensecret
+      - task: genconfig
+      - task: apply
+      - sleep 30
+      - echo "It might take some time to install Talos on your nodes and possibly reboot. Please ignore the errors and be patient"
+      - until talhelper gencommand bootstrap | bash ; do sleep 5; done
+      - sleep 5
+      - task: kubeconfig
+      - sleep 30
+      - echo "It might take some time for the controlplane to come up. Please ignore the errors and be patient"
+      - until kubectl wait --for=condition=Ready=False nodes --all --timeout=600s ; do sleep 5; done
+      - task: apply-extras
+      - until kubectl wait --for=condition=Ready nodes --all --timeout=600s ; do sleep 1; done
+      - talosctl health --server=false
+      - echo "All good to go!"
+
+  soft-nuke:
+    desc: Resets nodes back to maintenance mode so you can re-deploy again straight after
+    prompt: "This will destroy your cluster and reset the nodes back to maintenance mode. Are you sure?"
+    dir: "{{.TALOS_DIR}}"
+    cmd: talhelper gencommand reset --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash
+
+  hard-nuke:
+    desc: Resets nodes back completely and reboots them
+    prompt: "This will destroy your cluster and reset the nodes. Are you sure?"
+    dir: "{{.TALOS_DIR}}"
+    cmd: talhelper gencommand reset --extra-flags "--reboot --graceful=false --wait=false" | bash
 
   upgrade-talos:
     desc: Upgrade talos on a node

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ You have two different options for setting up your local workstation.
 
 #### Talos
 
-1. One-liner to deploy your cluster and bootstrap it. This generates secrets, generates the config files for your nodes and applies them. It bootstraps the cluster afterwards, fetches the kubeconfig file and installs Cilium and kubelet-csr-approver. It finis
+1. Deploy your cluster and bootstrap it. This generates secrets, generates the config files for your nodes and applies them. It bootstraps the cluster afterwards, fetches the kubeconfig file and installs Cilium and kubelet-csr-approver. It finishes with some health checks.
 
     ```sh
     task talos:deploy

--- a/README.md
+++ b/README.md
@@ -283,30 +283,10 @@ You have two different options for setting up your local workstation.
 
 #### Talos
 
-1. Create Talos Secrets and configuration
+1. One-liner to deploy your cluster and bootstrap it. This generates secrets, generates the config files for your nodes and applies them. It bootstraps the cluster afterwards, fetches the kubeconfig file and installs Cilium and kubelet-csr-approver. It finis
 
     ```sh
-    task talos:gensecret
-    task talos:genconfig
-    ```
-
-2. Apply Talos Config
-
-    ```sh
-    task talos:apply
-    ```
-
-3. Boostrap Talos and get kubeconfig
-
-    ```sh
-    task talos:bootstrap
-    task talos:kubeconfig node=$master_node_ip_address
-    ```
-
-4. Install Cilium and kubelet-csr-approver into the cluster
-
-    ```sh
-    task talos:apply-extras
+    task talos:deploy
     ```
 
 #### k3s
@@ -448,8 +428,14 @@ By default Flux will periodically check your git repository for changes. In orde
 There might be a situation where you want to destroy your Kubernetes cluster. This will completely clean the OS of all traces of the Kubernetes distribution you chose and then reboot the nodes.
 
 ```sh
-# Nuke k3s
+# k3s: Nuke
 task ansible:run playbook=cluster-nuke
+
+# Talos: Reset your nodes back to maintenance mode and reboot
+task talos:soft-nuke
+
+# Talos: Comletely format your the Talos installation and reboot
+task talos:hard-nuke
 ```
 
 ## 🤖 Renovate


### PR DESCRIPTION
This PR needs version 2.2 off talhelper. Might be wise to trigger a new build of your devcontainer base image before merging.

With the great work from @budimanjojo we now can use talhelper for all the steps needed to create commands to fetch kubeconfig and reset nodes.
With the help off that I created a one-liner deploy code which mainly re-uses the separate tasks, with some checks in between. Can't use `talosctl health` everywhere since it won't go to green until a CNI is installed.

Also added command for nuking your cluster in a soft and hard way.