### PR TITLE
feat(talos): add Talos and kubernetes version for talconfig

### DIFF
--- a/.github/tests/config-talos.yaml
+++ b/.github/tests/config-talos.yaml
@@ -4,6 +4,8 @@ skip_tests: true
 distribution:
   type: talos
   talos:
+    version: v1.6.4
+    kubernetesversion: v1.29.1
     schematicID: "df491c50a5acc05b977ef00c32050e1ceb0df746e40b33c643ac8a9bfb7c7263"
 
 timezone: Etc/UTC

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.6.4
+talosVersion: {{ distribution.talos.version }}
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.29.1
+kubernetesVersion: {{ distribution.talos.kubernetesversion }}
 
 clusterName: &cluster home-kubernetes
 endpoint: https://{{ cluster.endpoint_vip }}:6443
@@ -34,9 +34,9 @@ nodes:
     {% if distribution.talos.secureboot.enabled %}
     machineSpec:
       secureboot: true
-    talosImageURL: factory.talos.dev/installer-secureboot/{{ distribution.talos.schematicID }}
+    talosImageURL: factory.talos.dev/installer-secureboot/{{ distribution.talos.schematicID }}:{{ distribution.talos.version }}
     {% else %}
-    talosImageURL: factory.talos.dev/installer/{{ distribution.talos.schematicID }}
+    talosImageURL: factory.talos.dev/installer/{{ distribution.talos.schematicID }}:{{ distribution.talos.version }}
     {% endif %}
     controlPlane: {{ (item.controller) | string | lower }}
     networkInterfaces:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,5 +1,4 @@
 ---
-
 #
 # (Required) Distribution represents the Kubernetes distribution layer and any additional customizations
 #
@@ -9,6 +8,10 @@ distribution:
   type: k3s
   # (Optional) Talos Specific Options
   talos: {}
+    # # (Required) Get the latest Talos and corresponding kubernetes version from
+    # #   https://factory.talos.dev or https://github.com/siderolabs/talos/releases
+    # version: v1.6.4
+    # kubernetesversion: v1.29.1
     # # (Required) If you need any additional System Extensions and/or kernel arguments generate a schematic ID.
     # # Go to https://factory.talos.dev/ and choose the System Extensions you need and/or add extra kernel arguments.
     # # Otherwise use below default.
@@ -22,7 +25,7 @@ distribution:
     # bgp:
     #   enabled: true
     #   # (Optional) If using multiple BGP peers add them here.
-    #   #   Default is .1 derrived from host_network: ['x.x.x.1']
+    #   #   Default is .1 derived from host_network: ['x.x.x.1']
     #   peers: []
     #   # (Required) Set the BGP Autonomous System Number for the router(s) and nodes.
     #   #  If these match, iBGP will be used. If not, eBGP will be used.
@@ -72,7 +75,8 @@ nodes:
   search_domain: ""
   # (Required) Use only 1, 3 or more ODD number of controller nodes, recommended is 3
   #   Worker nodes are optional
-  inventory: []
+  inventory:
+    []
     # - name: ""               # Name of the node (must match [a-z0-9-\.]+)
     #   address: ""            # IP address of the node
     #   controller: true       # (Required) Set to true if this is a controller node


### PR DESCRIPTION
* Added Talos version
* Added kubernetes version
* Corrected minor grammar typo

Followed https://factory.talos.dev/ for talosImageURL construction. Testing of other versions than latest release of Talos is now possible.