### PR TITLE
Allow users to optionally override templates

### DIFF
--- a/bootstrap/overrides/readme.partial.yaml.j2
+++ b/bootstrap/overrides/readme.partial.yaml.j2
@@ -1,0 +1,5 @@
+<% Place user jinja template overrides in this file's directory %>
+<% Docs: https://mirkolenz.github.io/makejinja/makejinja.html %>
+<% Example: https://github.com/mirkolenz/makejinja/blob/main/tests/data/makejinja.toml %>
+<% Example: https://github.com/mirkolenz/makejinja/blob/main/tests/data/input1/not-empty.yaml.jinja %>
+<% Example: https://github.com/mirkolenz/makejinja/blob/main/tests/data/input2/not-empty.yaml.jinja %>

--- a/makejinja.toml
+++ b/makejinja.toml
@@ -1,5 +1,5 @@
 [makejinja]
-inputs = ["./bootstrap/templates"]
+inputs = ["./bootstrap/templates","./bootstrap/overrides"]
 output = "./"
 exclude_patterns = [".mjfilter.py", "*.partial.yaml.j2"]
 data = ["./config.yaml"]


### PR DESCRIPTION
In some cases its useful to override the templates from this repository with user defined customizations. We can include a simple "bootstrap/overrides" directory to provide a location (and readme example with links) that makejinja will process after running through the repository's baseline configuration. This helps the user keep following this repository for community updates while being able to patch in their own modifications that won't be overwritten and cause merge conflicts (from template repository updates).

This also doubles to provide a location where we can test additions to the repo without needing to modify the source files.