### PR TITLE
feat(talos): Allow users to include talhelper patches

### DIFF
--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -75,6 +75,10 @@ nodes:
           ip: "{{ cluster.endpoint_vip }}"
         {% endif %}
         {% endif %}
+    {% if distribution.talos.user_patches %}
+    patches:
+      - "@./patches/node_{{ item.name }}.yaml"
+    {% endif %}
   {% endfor %}
 
 patches:
@@ -183,6 +187,10 @@ patches:
             - slot: 0
               tpm: {}
   {% endif %}
+  {% if distribution.talos.user_patches %}
+  # User specified global patches
+  - "@./patches/global.yaml"
+  {% endif %}
 
 controlPlane:
   patches:
@@ -224,3 +232,14 @@ controlPlane:
             allowedKubernetesNamespaces:
               - system-upgrade
 
+    {% if distribution.talos.user_patches %}
+    # User specified controlPlane patches
+    - "@./patches/controlPlane.yaml"
+    {% endif %}
+
+{% if nodes.inventory | selectattr('controller', 'equalto', False) | list | length %}
+worker:
+  patches:
+    # User specified worker patches
+    - "@./patches/worker.yaml"
+{% endif %}

--- a/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/talos/talconfig.yaml.j2
@@ -237,7 +237,8 @@ controlPlane:
     - "@./patches/controlPlane.yaml"
     {% endif %}
 
-{% if nodes.inventory | selectattr('controller', 'equalto', False) | list | length %}
+{% if ( (distribution.talos.user_patches) and
+        (nodes.inventory | selectattr('controller', 'equalto', False) | list | length) ) %}
 worker:
   patches:
     # User specified worker patches

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -40,6 +40,15 @@ distribution:
     #   # (Optional) Enable TPM-based disk encryption. Requires TPM 2.0
     #   #   See: https://www.talos.dev/v1.6/talos-guides/install/bare-metal-platforms/secureboot/#disk-encryption-with-tpm
     #   encrypt_disk_with_tpm: true
+    # user_patches: true
+    # # (Optional) Add includes for user provided patches to generated talconfig.yaml.
+    # #   See: https://github.com/budimanjojo/talhelper/blob/179ba9ed42f70069c7842109bea24f769f7af6eb/example/extraKernelArgs-patch.yaml
+    # #   Patches are applied in this order. (global overrides cp/worker which overrides node-specific).
+    # #   Create these files to allow talos:bootstrap-genconfig to complete (empty files are ok).
+    # #     kubernetes/talos/patches/node_<name>.yaml  # Patches for individual nodes
+    # #     kubernetes/talos/patches/controlPlane.yaml # Patches for controlplane nodes
+    # #     kubernetes/talos/patches/worker.yaml       # Patches for worker nodes
+    # #     kubernetes/talos/patches/global.yaml       # Patches for ALL nodes
 
 #
 # (Required) Timezone is your IANA formatted timezone (e.g. America/New_York)


### PR DESCRIPTION
Talhelper allows us to include [external patch files](https://github.com/budimanjojo/talhelper/blob/179ba9ed42f70069c7842109bea24f769f7af6eb/example/talconfig.yaml#L134) outside of the main `talconfig.yaml`. We can use this feature to allow the user to create [patches](https://github.com/budimanjojo/talhelper/blob/179ba9ed42f70069c7842109bea24f769f7af6eb/example/extraKernelArgs-patch.yaml) that can be maintained separately from the template generated talconfig. This can be used similarly to [this PR](https://github.com/onedr0p/cluster-template/pull/1319) for talos specific overrides.

When enabling `distribution.talos.user_patches` the includes for the following files are added to the generated talconfig.yaml. These patches are applied to the talconfig file's sections of the same name. 
- kubernetes/talos/patches/controlPlane.yaml
- kubernetes/talos/patches/global.yaml
- kubernetes/talos/patches/node_name.yaml (name from `nodes.inventory.[].name`)
- kubernetes/talos/patches/worker.yaml

I haven't figured out how to get `makejinja` (or similar like ansible/go-task) to optionally generate these as empty files **if they don't already exist**. The goal is to not stomp these files each time we update our local repo with the latest changes from the template repo. These are particularly useful for nodes that have specific differences from the global defaults due to different worker hardware, existance as a virtual machine, or similar.