### PR TITLE
fix(cilium): disable BPF masquerade

### DIFF
--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -2,7 +2,7 @@ autoDirectNodeRoutes: true
 bgpControlPlane:
   enabled: true
 bpf:
-  masquerade: true
+  masquerade: false
 cgroup:
   automount:
     enabled: false

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -2,7 +2,7 @@ autoDirectNodeRoutes: true
 bgpControlPlane:
   enabled: true
 bpf:
-  masquerade: true
+  masquerade: false
 cgroup:
   automount:
     enabled: false


### PR DESCRIPTION
It could cause issues/complications with more advanced networking configuration on the host (e.g. using FRR OpenFabric for host-level routing between nodes, or using other eBPF apps with Cilium). 

There's also no real advantage to using in homelab, so it should be safer to disable this.