### PR TITLE
Fix cluster-kube-vip playbook

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-kube-vip.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-kube-vip.yaml.j2
@@ -19,6 +19,6 @@
 
     - name: Upgrade kube-vip
       ansible.builtin.template:
-        src: templates/kube-vip-ds.yaml.j2
+        src: templates/kube-vip-ds.yaml
         dest: "{{ k3s_server_manifests_dir }}/kube-vip-ds.yaml"
         mode: preserve


### PR DESCRIPTION
The playbook uses the generated cluster-kube-vip.yaml, not the template file.