### PR TITLE
fix: Allow users to optionally override templates

### DIFF
--- a/makejinja.toml
+++ b/makejinja.toml
@@ -1,5 +1,5 @@
 [makejinja]
-inputs = ["./bootstrap/templates","./bootstrap/overrides"]
+inputs = ["./bootstrap/overrides","./bootstrap/templates"]
 output = "./"
 exclude_patterns = [".mjfilter.py", "*.partial.yaml.j2"]
 data = ["./config.yaml"]


### PR DESCRIPTION
Looks like the logic was reversed in #1319. That change allowed non-existant files in bootstrap/templates to be created, but couldn't override existing files. The inputs need to be swapped to allow the overrides to be applied with preference (if they exist).

This affect can be seen in makejinja's examples:

- https://github.com/mirkolenz/makejinja/blob/main/tests/data/makejinja.toml
  - inputs = ["./input1", "./input2"]
- https://github.com/mirkolenz/makejinja/blob/main/tests/data/input1/not-empty.yaml.jinja
- https://github.com/mirkolenz/makejinja/blob/main/tests/data/input2/not-empty.yaml.jinja
- https://github.com/mirkolenz/makejinja/blob/main/tests/data/output/not-empty.yaml

This allowed me to apply a patch to the ingress-nginx instances without changing the source template files.
```
$ cat kubernetes/apps/network/ingress-nginx/internal/kustomization.yaml 
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - ./helmrelease.yaml

$ grep input makejinja.toml 
inputs = ["./bootstrap/overrides","./bootstrap/templates"]

$ cat bootstrap/overrides/kubernetes/apps/network/ingress-nginx/internal/kustomization.yaml.j2 
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - ./helmrelease.yaml
patches:
  - path: helmrelease-values.yaml
    target:
      kind: HelmRelease

$ cat bootstrap/overrides/kubernetes/apps/network/ingress-nginx/internal/helmrelease-values.yaml.j2 
---
apiVersion: helm.toolkit.fluxcd.io/v2beta2
kind: HelmRelease
metadata:
  name: ingress-nginx-internal
spec:
  values:
    controller:
      replicaCount: 2

$ task configure -y

$ cat kubernetes/apps/network/ingress-nginx/internal/kustomization.yaml 
---
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
  - ./helmrelease.yaml
patches:
  - path: helmrelease-values.yaml
    target:
      kind: HelmRelease

$ cat kubernetes/apps/network/ingress-nginx/internal/helmrelease-values.yaml
---
apiVersion: helm.toolkit.fluxcd.io/v2beta2
kind: HelmRelease
metadata:
  name: ingress-nginx-internal
spec:
  values:
    controller:
      replicaCount: 2
```