### PR TITLE
Add optional user tasks to Taskfile.yaml

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -36,6 +36,9 @@ includes:
   talos: .taskfiles/Talos/Taskfile.yaml
   sops: .taskfiles/Sops/Taskfile.yaml
   workstation: .taskfiles/Workstation/Taskfile.yaml
+  user:
+    taskfile: .taskfiles/User
+    optional: true
 
 tasks:
 


### PR DESCRIPTION
Go-task supports [including optional](https://taskfile.dev/usage/#optional-includes) user taskfiles and directories . This allows us to use our own custom tasks without needing to edit the repo root Taskfile.yaml. Useful for reducing merge conflicts in the future for those following along with the cluster-template's regular updates.

Example:
```
$ find .taskfiles/User
.taskfiles/User
.taskfiles/User/app1
.taskfiles/User/app1/Taskfile.yaml
.taskfiles/User/app2
.taskfiles/User/app2/Taskfile.yaml
.taskfiles/User/Taskfile.yaml

$ cat .taskfiles/User/Taskfile.yaml
version: '3'
includes:
  app1: app1
  app2:
    taskfile: app2
 
$ cat .taskfiles/User/app1/Taskfile.yaml
version: '3'
tasks:
  greet1:
    cmds:
      - echo app1
    desc: test2

$ cat .taskfiles/User/app2/Taskfile.yaml
version: '3'
tasks:
  greet2:
    cmds:
      - echo app2
    desc: test2

$ task | grep "^task\|user"
task: [default] task -l
task: Available tasks for this project:
* user:app1:greet1:                test1
* user:app2:greet2:                test2
```