### PR TITLE
Add the option for assigning a specific SSH key to a node.

### DIFF
--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -8,7 +8,7 @@ kubernetes:
         "#{ item.name }#":
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
-          #% if item.ssh_key is defined and item.ssh_key|length %#
+          #% if item.ssh_key %#
           ansible_ssh_private_key_file: "#{ item.ssh_key }#"
           #% endif %#
         #% endif %#

--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -9,7 +9,7 @@ kubernetes:
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
           #% if item.ssh_key is defined and item.ssh_key|length %#
-          ansible_ssh_private_key_file: "{{ item.ssh_key }}"
+          ansible_ssh_private_key_file: "#{ item.ssh_key }#"
           #% endif %#
         #% endif %#
         #% endfor %#
@@ -22,7 +22,7 @@ kubernetes:
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
           #% if item.ssh_key is defined and item.ssh_key|length %#
-          ansible_ssh_private_key_file: "{{ item.ssh_key }}"
+          ansible_ssh_private_key_file: "#{ item.ssh_key }#"
           #% endif %#
         #% endif %#
         #% endfor %#

--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -8,6 +8,9 @@ kubernetes:
         "#{ item.name }#":
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
+          #% if item.ssh_key is defined and item.ssh_key|length %#
+          ansible_ssh_private_key_file: "{{ item.ssh_key }}"
+          #% endif %#
         #% endif %#
         #% endfor %#
     #% if bootstrap_node_inventory | selectattr('controller', 'equalto', False) | list | length %#
@@ -18,6 +21,9 @@ kubernetes:
         "#{ item.name }#":
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
+          #% if item.ssh_key is defined and item.ssh_key|length %#
+          ansible_ssh_private_key_file: "{{ item.ssh_key }}"
+          #% endif %#
         #% endif %#
         #% endfor %#
     #% endif %#

--- a/bootstrap/templates/ansible/inventory/hosts.yaml.j2
+++ b/bootstrap/templates/ansible/inventory/hosts.yaml.j2
@@ -21,7 +21,7 @@ kubernetes:
         "#{ item.name }#":
           ansible_user: "#{ item.ssh_user }#"
           ansible_host: "#{ item.address }#"
-          #% if item.ssh_key is defined and item.ssh_key|length %#
+          #% if item.ssh_key %#
           ansible_ssh_private_key_file: "#{ item.ssh_key }#"
           #% endif %#
         #% endif %#

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -46,8 +46,8 @@ bootstrap_node_default_gateway: ""
 # (Required) Use only 1, 3 or more ODD number of controller nodes, recommended is 3
 #   Worker nodes are optional
 bootstrap_node_inventory: []
-    # - name: ""           # Name of the node (must match [a-z0-9-\.]+)
-    #   address: ""        # IP address of the node
+    # - name: ""           # (Required) Name of the node (must match [a-z0-9-\.]+)
+    #   address: ""        # (Required) IP address of the node
     #   controller: true   # (Required) Set to true if this is a controller node
     #   ssh_user: ""       # (Required: k3s) SSH username of the node
     #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -51,7 +51,7 @@ bootstrap_node_inventory: []
     #   controller: true   # (Required) Set to true if this is a controller node
     #   ssh_user: ""       # (Required: k3s) SSH username of the node
     #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node
-    #   ssh_key: ""        # (Optional) Set specific SSH key for this node
+    #   ssh_key: ""        # (Optional: k3s) Set specific SSH key for this node
     # ...
 
 # (Optional) The DNS server to use for the cluster, this can be an existing

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -46,11 +46,12 @@ bootstrap_node_default_gateway: ""
 # (Required) Use only 1, 3 or more ODD number of controller nodes, recommended is 3
 #   Worker nodes are optional
 bootstrap_node_inventory: []
-    # - name: ""          # Name of the node (must match [a-z0-9-\.]+)
-    #   address: ""       # IP address of the node
-    #   controller: true  # (Required) Set to true if this is a controller node
-    #   ssh_user: ""      # (Required: k3s) SSH username of the node
-    #   talos_disk: ""    # (Required: Talos) Device path or serial number of the disk for this node
+    # - name: ""           # Name of the node (must match [a-z0-9-\.]+)
+    #   address: ""        # IP address of the node
+    #   controller: true   # (Required) Set to true if this is a controller node
+    #   ssh_user: ""       # (Required: k3s) SSH username of the node
+    #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node
+    #   ssh_key: ""        # (Optional) Set specific SSH key for this node
     # ...
 
 # (Optional) The DNS server to use for the cluster, this can be an existing


### PR DESCRIPTION
I personally prefer to store key as a named value in my `~/.ssh/` directory, but the configs have no way of allowing for that (or at least I wasn't able to find any) - this should account for it, and only set it when that variable has been specified.

It was my first time editing jinja templates, so I hope it's fine - it works a-okay on my end.