### PR TITLE
Update echo-server app-template ingress' v3 service identifier

### DIFF
--- a/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/echo-server/app/helmrelease.yaml.j2
@@ -88,7 +88,7 @@ spec:
             paths:
               - path: /
                 service:
-                  name: main
+                  identifier: app
                   port: http
         tls:
           - hosts:


### PR DESCRIPTION
Ran into flux-local errors for echo-server's ingress service until its service name/identifier was updated to match the new app-template v3 service name.