### PR TITLE
feat(talos): change from `net.ifnames` to a macaddr `deviceSelector`

### DIFF
--- a/.github/tests/config-talos.yaml
+++ b/.github/tests/config-talos.yaml
@@ -12,10 +12,12 @@ bootstrap_node_inventory:
     address: 10.10.10.100
     controller: true
     talos_disk: fake
+    talos_nic: fake
   - name: k8s-worker-0
     address: 10.10.10.101
     controller: false
     talos_disk: fake
+    talos_nic: fake
 bootstrap_dns_servers: ["1.1.1.1"]
 bootstrap_search_domain: "fake"
 bootstrap_pod_network: 10.69.0.0/16

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-l3.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/cilium-l3.yaml.j2
@@ -3,7 +3,7 @@
 apiVersion: cilium.io/v2alpha1
 kind: CiliumBGPPeeringPolicy
 metadata:
-  name: policy
+  name: l3-policy
 spec:
   nodeSelector:
     matchLabels:
@@ -31,7 +31,8 @@ spec:
 apiVersion: cilium.io/v2alpha1
 kind: CiliumLoadBalancerIPPool
 metadata:
-  name: pool
+  name: l3-pool
 spec:
-  cidrs:
+  allowFirstLastIPs: "Yes"
+  blocks:
     - cidr: "${BGP_ADVERTISED_CIDR}"

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/kustomization.yaml.j2
@@ -2,10 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  #% if bootstrap_bgp.enabled %#
-  - ./cilium-bgp.yaml
-  #% endif %#
-  #% if ((not bootstrap_bgp.enabled) and (not bootstrap_feature_gates.dual_stack_ipv4_first)) %#
-  - ./cilium-l2.yaml
-  #% endif %#
   - ./helmrelease.yaml

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml.j2
@@ -1,3 +1,4 @@
+#% if ((not bootstrap_bgp.enabled) and (not bootstrap_feature_gates.dual_stack_ipv4_first)) %#
 ---
 # https://docs.cilium.io/en/latest/network/l2-announcements
 apiVersion: cilium.io/v2alpha1
@@ -22,3 +23,4 @@ spec:
   allowFirstLastIPs: "Yes"
   blocks:
     - cidr: "${NODE_CIDR}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/cilium-l3.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/cilium-l3.yaml.j2
@@ -1,0 +1,40 @@
+#% if bootstrap_bgp.enabled %#
+---
+# https://docs.cilium.io/en/latest/network/bgp-control-plane/
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeeringPolicy
+metadata:
+  name: l3-policy
+spec:
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/os: linux
+  virtualRouters:
+    - localASN: #{ bootstrap_bgp.local_asn }#
+      neighbors:
+        #% if bootstrap_bgp.peers %#
+        #% for item in bootstrap_bgp.peers %#
+        - peerAddress: "#{ item }#/32"
+          peerASN: #{ bootstrap_bgp.peer_asn }#
+        #% endfor %#
+        #% else %#
+        #% if bootstrap_node_default_gateway %#
+        - peerAddress: "#{ bootstrap_node_default_gateway }#/32"
+        #% else %#
+        - peerAddress: "#{ bootstrap_node_network | nthhost(1) }#/32"
+        #% endif %#
+          peerASN: #{ bootstrap_bgp.peer_asn }#
+        #% endif %#
+      serviceSelector:
+        matchExpressions:
+          - {key: somekey, operator: NotIn, values: ['never-used-value']}
+---
+apiVersion: cilium.io/v2alpha1
+kind: CiliumLoadBalancerIPPool
+metadata:
+  name: l3-pool
+spec:
+  allowFirstLastIPs: "Yes"
+  blocks:
+    - cidr: "${BGP_ADVERTISED_CIDR}"
+#% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/kustomization.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/config/kustomization.yaml.j2
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  #% if bootstrap_bgp.enabled %#
+  - ./cilium-l3.yaml
+  #% endif %#
+  #% if ((not bootstrap_bgp.enabled) and (not bootstrap_feature_gates.dual_stack_ipv4_first)) %#
+  - ./cilium-l2.yaml
+  #% endif %#

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/ks.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/ks.yaml.j2
@@ -18,3 +18,25 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-config
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cilium
+  path: ./kubernetes/apps/kube-system/cilium/config
+  prune: false # never should be deleted
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -40,7 +40,8 @@ nodes:
     #% endif %#
     controlPlane: #{ (item.controller) | string | lower }#
     networkInterfaces:
-      - interface: eth0
+      - deviceSelector:
+          hardwareAddr: "#{ item.talos_nic }#"
         dhcp: false
         #% if bootstrap_talos.vlan %#
         vlans:
@@ -122,8 +123,7 @@ patches:
           image-gc-high-threshold: 55
           rotate-server-certificates: true
         nodeIP:
-          validSubnets:
-            - "#{ bootstrap_node_network }#"
+          validSubnets: ["#{ bootstrap_node_network }#"]
 
   # Force nameserver
   - |-
@@ -139,8 +139,7 @@ patches:
     machine:
       time:
         disabled: false
-        servers:
-          - time.cloudflare.com
+        servers: ["time.cloudflare.com"]
 
   # Custom sysctl settings
   - |-
@@ -158,17 +157,7 @@ patches:
           - destination: /var/openebs/local
             type: bind
             source: /var/openebs/local
-            options:
-              - bind
-              - rshared
-              - rw
-
-  # Disable predictable NIC naming
-  - |-
-    machine:
-      install:
-        extraKernelArgs:
-          - net.ifnames=0
+            options: ["bind", "rshared", "rw"]
 
   #% if bootstrap_talos.secureboot.enabled and bootstrap_talos.secureboot.encrypt_disk_with_tpm %#
   # Encrypt system disk with TPM
@@ -186,6 +175,7 @@ patches:
             - slot: 0
               tpm: {}
   #% endif %#
+
   #% if bootstrap_talos.user_patches %#
   # User specified global patches
   - "@./patches/global.yaml"
@@ -226,10 +216,8 @@ controlPlane:
         features:
           kubernetesTalosAPIAccess:
             enabled: true
-            allowedRoles:
-              - os:admin
-            allowedKubernetesNamespaces:
-              - system-upgrade
+            allowedRoles: ["os:admin"]
+            allowedKubernetesNamespaces: ["system-upgrade"]
 
     #% if bootstrap_talos.user_patches %#
     # User specified controlPlane patches

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -15,9 +15,8 @@ containerRuntime:
   #% if bootstrap_distribution in ["k3s"] %#
   socketPath: /var/run/k3s/containerd/containerd.sock
   #% endif %#
-# NOTE: This might need to be set if you have more than one active NIC on your hosts
-# devices:
-#   - eno0
+# NOTE: devices might need to be set if you have more than one active NIC on your hosts
+# devices: eno+ eth+
 endpointRoutes:
   enabled: true
 #% if bootstrap_cloudflare.enabled %#

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -15,9 +15,8 @@ containerRuntime:
   #% if bootstrap_distribution in ["k3s"] %#
   socketPath: /var/run/k3s/containerd/containerd.sock
   #% endif %#
-# NOTE: This might need to be set if you have more than one active NIC on your hosts
-# devices:
-#   - eno0
+# NOTE: devices might need to be set if you have more than one active NIC on your hosts
+# devices: eno+ eth+
 endpointRoutes:
   enabled: true
 hubble:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -49,7 +49,8 @@ bootstrap_node_inventory: []
     # - name: ""           # (Required) Name of the node (must match [a-z0-9-\.]+)
     #   address: ""        # (Required) IP address of the node
     #   controller: true   # (Required) Set to true if this is a controller node
-    #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node
+    #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
+    #   talos_nic: ""      # (Required: Talos) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
     #   ssh_user: ""       # (Required: k3s) SSH username of the node
     #   ssh_key: ""        # (Optional: k3s) Set specific SSH key for this node
     # ...


### PR DESCRIPTION
- Remove `net.ifnames` patch and require people to give a mac address per node for Talos
- Update Cilium configs and address some deprecations