### PR TITLE
Fix cilium to use k3s paths for binPath and confPath

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -52,7 +52,7 @@
           loop: ["filter", "nat", "mangle", "raw"]
         - name: Networking | Delete CNI directory
           ansible.builtin.file:
-            path: /etc/cni/net.d
+            path: /var/lib/rancher/k3s/agent/etc/cni/net.d
             state: absent
 
     - name: Check to see if k3s-killall.sh exits

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -10,6 +10,11 @@ cgroup:
 cluster:
   id: 1
   name: home-kubernetes
+#% if bootstrap_distribution in ["k3s"] %#
+cni:
+  binPath: /var/lib/rancher/k3s/data/current/bin
+  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+#% endif %#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -10,6 +10,11 @@ cgroup:
 cluster:
   id: 1
   name: home-kubernetes
+#% if bootstrap_distribution in ["k3s"] %#
+cni:
+  binPath: /var/lib/rancher/k3s/data/current/bin
+  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+#% endif %#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#


### PR DESCRIPTION
Cilium incorrectly uses the `/etc/cni/net.d` and `/opt/cni/bin` directories in the node filesystem instead of the corresponding directories in `/var/lib/rancher/k3s`.