### PR TITLE
Add support for machine files

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -80,6 +80,11 @@ nodes:
     patches:
       - "@./patches/node_#{ item.name }#.yaml"
     #% endif %#
+    #% if bootstrap_talos.machine_files %#
+    machineFiles:
+      - "@./machine_files/node_#{ item.name }#.yaml"
+    #% endif %#
+
   #% endfor %#
 
 patches:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -38,6 +38,11 @@ bootstrap_talos:
   #     kubernetes/bootstrap/talos/patches/worker.yaml       # Patches for worker nodes
   #     kubernetes/bootstrap/talos/patches/global.yaml       # Patches for ALL nodes
   user_patches: false
+  # (Optional) Add includes for user provided machineFiles to generated talconfig.yaml.
+  #   See: https://github.com/budimanjojo/talhelper/blob/179ba9ed42f70069c7842109bea24f769f7af6eb/example/talconfig.yaml#L54
+  #   Create these files to allow talos:bootstrap-genconfig to complete (empty files are ok).
+  #     kubernetes/bootstrap/talos/machine_files/node_<name>.yaml  # Machine file for individual nodes
+  machine_files: false
 
 # (Required) The CIDR your nodes are on (e.g. 192.168.1.0/24)
 bootstrap_node_network: ""


### PR DESCRIPTION
This should add support for machineFiles https://www.talos.dev/v1.6/reference/configuration/v1alpha1/config/#Config.machine.files. to talosconfig

edit: This approach likely doesn't work. Filed: https://github.com/budimanjojo/talhelper/issues/393