### PR TITLE
Revert "Fix cilium to use k3s paths for binPath and confPath"

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -52,7 +52,7 @@
           loop: ["filter", "nat", "mangle", "raw"]
         - name: Networking | Delete CNI directory
           ansible.builtin.file:
-            path: /var/lib/rancher/k3s/agent/etc/cni/net.d
+            path: /etc/cni/net.d
             state: absent
 
     - name: Check to see if k3s-killall.sh exits

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -9,12 +9,7 @@ cgroup:
   hostRoot: /sys/fs/cgroup
 cluster:
   id: 1
-  name: "#{ bootstrap_cluster_name|default('home-kubernetes', true) }#"
-#% if bootstrap_distribution in ["k3s"] %#
-cni:
-  binPath: /var/lib/rancher/k3s/data/current/bin
-  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
-#% endif %#
+  name: #{ bootstrap_cluster_name|default('home-kubernetes', true) }#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -9,12 +9,7 @@ cgroup:
   hostRoot: /sys/fs/cgroup
 cluster:
   id: 1
-  name: "#{ bootstrap_cluster_name|default('home-kubernetes', true) }#"
-#% if bootstrap_distribution in ["k3s"] %#
-cni:
-  binPath: /var/lib/rancher/k3s/data/current/bin
-  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
-#% endif %#
+  name: #{ bootstrap_cluster_name|default('home-kubernetes', true) }#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#


### PR DESCRIPTION
@prehor I need to revert this change. People are reporting issues in Discord https://discord.com/channels/673534664354430999/1221220838812946523

As I know this works with the previous paths I feel it's safe to revert and maybe debug what is the root cause

Reverts onedr0p/cluster-template#1381
