### PR TITLE
fix(metrics-server): Remove --kubelet-insecure-tls

### DIFF
--- a/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
@@ -22,7 +22,6 @@ spec:
       retries: 3
   values:
     args:
-      - --kubelet-insecure-tls
       - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
       - --kubelet-use-node-status-port
       - --metric-resolution=15s

--- a/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/metrics-server/app/helmrelease.yaml.j2
@@ -25,6 +25,9 @@ spec:
       - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
       - --kubelet-use-node-status-port
       - --metric-resolution=15s
+      #% if bootstrap_distribution in ["k3s"] %#
+      - --kubelet-insecure-tls
+      #% endif %#
     metrics:
       enabled: true
     serviceMonitor:


### PR DESCRIPTION
According to https://www.talos.dev/v1.6/kubernetes-guides/configuration/deploy-metrics-server, this flag is not necessary when enabling certificate rotation and an auto CSR approver.