### PR TITLE
Disable node.ssh_user check

### DIFF
--- a/bootstrap/scripts/validation.py
+++ b/bootstrap/scripts/validation.py
@@ -56,7 +56,7 @@ def validate_node(node: dict, node_cidr: str, distribution: str) -> None:
         raise ValueError(f"A node is missing a name")
     if not re.match(r"^[a-z0-9-\.]+$", node.get('name')):
         raise ValueError(f"Node {node.get('name')} has an invalid name")
-    if not node.get("ssh_user") and distribution not in ["k3s"]:
+    if not node.get("ssh_user") and distribution in ["k3s"]:
         raise ValueError(f"Node {node.get('name')} is missing ssh_user")
     if not node.get("talos_disk") and distribution in ["talos"]:
         raise ValueError(f"Node {node.get('name')} is missing talos_disk")


### PR DESCRIPTION
Validation.py script unnecessarily checking for node.ssh_user when distribution is set to "talos".