### PR TITLE
Fix cilium to use k3s paths for binPath and confPath v2

### DIFF
--- a/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-installation.yaml.j2
@@ -25,6 +25,36 @@
       when: k3s_installed.stat.exists
       ansible.builtin.include_tasks: tasks/version-check.yaml
 
+    - name: Ensure that the /opt/cni directory exists
+      ansible.builtin.file:
+        path: /opt/cni
+        mode: '755'
+        state: directory
+    - name: Ensure that the /opt/cni/bin is a link to /var/lib/rancher/k3s/data/current/bin
+      ansible.builtin.file:
+        src: /var/lib/rancher/k3s/data/current/bin
+        dest: /opt/cni/bin
+        follow: false
+        force: true
+        state: link
+
+    - name: Ensure that the /etc/cni directory exists
+      ansible.builtin.file:
+        path: /etc/cni
+        mode: '755'
+        state: directory
+    - name: Ensure that the /var/lib/rancher/k3s/agent/etc/cni/net.d directory exists
+      ansible.builtin.file:
+        path: /var/lib/rancher/k3s/agent/etc/cni/net.d
+        mode: '755'
+        state: directory
+    - name: Ensure that the /etc/cni/net.d is a link to /var/lib/rancher/k3s/agent/etc/cni/net.d
+      ansible.builtin.file:
+        src: /var/lib/rancher/k3s/agent/etc/cni/net.d
+        dest: /etc/cni/net.d
+        force: true
+        state: link
+
     - name: Install Kubernetes
       ansible.builtin.include_role:
         name: xanmanning.k3s

--- a/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
+++ b/bootstrap/templates/ansible/playbooks/cluster-nuke.yaml.j2
@@ -50,7 +50,11 @@
             flush: true
             ip_version: ipv6
           loop: ["filter", "nat", "mangle", "raw"]
-        - name: Networking | Delete CNI directory
+        - name: Networking | Delete CNI bin link
+          ansible.builtin.file:
+            path: /opt/cni/bin
+            state: absent
+        - name: Networking | Delete CNI conf link
           ansible.builtin.file:
             path: /etc/cni/net.d
             state: absent

--- a/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-full.partial.yaml.j2
@@ -10,6 +10,11 @@ cgroup:
 cluster:
   id: 1
   name: #{ bootstrap_cluster_name|default('home-kubernetes', true) }#
+#% if bootstrap_distribution in ["k3s"] %#
+cni:
+  binPath: /var/lib/rancher/k3s/data/current/bin
+  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+#% endif %#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#

--- a/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
+++ b/bootstrap/templates/partials/cilium-values-init.partial.yaml.j2
@@ -10,6 +10,11 @@ cgroup:
 cluster:
   id: 1
   name: #{ bootstrap_cluster_name|default('home-kubernetes', true) }#
+#% if bootstrap_distribution in ["k3s"] %#
+cni:
+  binPath: /var/lib/rancher/k3s/data/current/bin
+  confPath: /var/lib/rancher/k3s/agent/etc/cni/net.d
+#% endif %#
 containerRuntime:
   integration: containerd
   #% if bootstrap_distribution in ["k3s"] %#


### PR DESCRIPTION
Cilium incorrectly uses the `/etc/cni/net.d` and `/opt/cni/bin` directories in the node filesystem instead of the corresponding directories in `/var/lib/rancher/k3s`.

Fixes PR #1381 where links `/etc/cni/net.d` and `/opt/cni/bin` to the corresponding directories in `/var/lib/rancher/k3s` were missing.