### PR TITLE
Make deviceSelector.hardwareAddr in config.yaml case-insensitive

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -41,7 +41,7 @@ nodes:
     controlPlane: #{ (item.controller) | string | lower }#
     networkInterfaces:
       - deviceSelector:
-          hardwareAddr: "#{ item.talos_nic }#"
+          hardwareAddr: "#{ item.talos_nic | lower }#"
         dhcp: false
         #% if bootstrap_talos.vlan %#
         vlans:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -54,7 +54,7 @@ bootstrap_node_inventory: []
     #   address: ""        # (Required) IP address of the node
     #   controller: true   # (Required) Set to true if this is a controller node
     #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
-    #   talos_nic: ""      # (Required: Talos) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
+    #   talos_nic: ""      # (Required: Talos) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure) NOTE: the MAC address is CASE-SENSITIVE. Make sure the MAC address is lowercase.
     #   ssh_user: ""       # (Required: k3s) SSH username of the node
     #   ssh_key: ""        # (Optional: k3s) Set specific SSH key for this node
     # ...

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -54,7 +54,7 @@ bootstrap_node_inventory: []
     #   address: ""        # (Required) IP address of the node
     #   controller: true   # (Required) Set to true if this is a controller node
     #   talos_disk: ""     # (Required: Talos) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
-    #   talos_nic: ""      # (Required: Talos) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure) NOTE: the MAC address is CASE-SENSITIVE. Make sure the MAC address is lowercase.
+    #   talos_nic: ""      # (Required: Talos) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
     #   ssh_user: ""       # (Required: k3s) SSH username of the node
     #   ssh_key: ""        # (Optional: k3s) Set specific SSH key for this node
     # ...


### PR DESCRIPTION
When setting up my new Talos-based cluster, I stumbled upon an issue with case sensitivity.

The Terraform provider for Proxmox wanted the MAC address to be uppercase, so I made it as such in the config, from which I sourced the address (for idempotence and DRY sake). In turn, Talos could not assign the VIP to any node. After making the MAC address lowercase (and just using upper() in Terraform), the VIP worked successfully.

I am adding this in the documentation, so that no other homelabber has issue with this. This could probably also be fixed with a PR to Talos, but for now, I'm adding this to the documentation.

Relevant issue in Talos's repo: https://github.com/siderolabs/talos/issues/8176