### PR TITLE
Clarify direnv setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,20 @@ You have two different options for setting up your local workstation.
     pacman -S --noconfirm direnv
     ```
 
-    📍 _After `direnv` is installed be sure to **[hook it into your preferred shell](https://direnv.net/docs/hook.html)** and then run `task workstation:direnv`_
+3. [Hook `direnv` into your preferred shell](https://direnv.net/docs/hook.html), then run:
 
-3. Install the additional **required** CLI tools
+    ```sh
+    task workstation:direnv
+    ```
+
+    📍 _**Verify** that `direnv` is setup properly by opening a new terminal and `cd`ing into your repository. You should see something like:_
+    ```sh
+    cd /path/to/repo
+    direnv: loading /path/to/repo/.envrc
+    direnv: export +ANSIBLE_COLLECTIONS_PATH +ANSIBLE_INVENTORY_UNPARSED_WARNING +ANSIBLE_LOCALHOST_WARNING +ANSIBLE_ROLES_PATH +ANSIBLE_VARS_ENABLED +K8S_AUTH_KUBECONFIG +KUBECONFIG +PYTHONDONTWRITEBYTECODE +SOPS_AGE_KEY_FILE +TALOSCONFIG +VIRTUAL_ENV ~PATH
+    ```
+
+6. Install the additional **required** CLI tools
 
    📍 _**Not using Homebrew or ArchLinux?** Try using the generic Linux task below, if that fails check out the [Brewfile](.taskfiles/Workstation/Brewfile)/[Archfile](.taskfiles/Workstation/Archfile) for what CLI tools needed and install them._
 
@@ -196,7 +207,7 @@ You have two different options for setting up your local workstation.
     task workstation:generic-linux
     ```
 
-4. Setup a Python virual environment by running the following task command.
+7. Setup a Python virual environment by running the following task command.
 
     📍 _This commands requires Python 3.11+ to be installed._
 
@@ -204,7 +215,7 @@ You have two different options for setting up your local workstation.
     task workstation:venv
     ```
 
-5. Continue on to 🔧 [**Stage 3**](#-stage-3-bootstrap-configuration)
+8. Continue on to 🔧 [**Stage 3**](#-stage-3-bootstrap-configuration)
 
 ### 🔧 Stage 3: Bootstrap configuration
 
@@ -293,7 +304,7 @@ You have two different options for setting up your local workstation.
 
 2. Verify the nodes are online
 
-    📍 _If this command **fails** you likely haven't configured `direnv` as mentioned previously in the guide._
+    📍 _If this command **fails** you likely haven't configured `direnv` as [mentioned previously](#non-devcontainer-method) in the guide._
 
     ```sh
     kubectl get nodes -o wide

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ You have two different options for setting up your local workstation.
     ```sh
     cd /path/to/repo
     direnv: loading /path/to/repo/.envrc
-    direnv: export +ANSIBLE_COLLECTIONS_PATH +ANSIBLE_INVENTORY_UNPARSED_WARNING +ANSIBLE_LOCALHOST_WARNING +ANSIBLE_ROLES_PATH +ANSIBLE_VARS_ENABLED +K8S_AUTH_KUBECONFIG +KUBECONFIG +PYTHONDONTWRITEBYTECODE +SOPS_AGE_KEY_FILE +TALOSCONFIG +VIRTUAL_ENV ~PATH
+    direnv: export +ANSIBLE_COLLECTIONS_PATH ...  +VIRTUAL_ENV ~PATH
     ```
 
 6. Install the additional **required** CLI tools


### PR DESCRIPTION
I missed the `task workstation:direnv` command in the README because of the way it is formatted. Instead of being called out in a code block, like the other steps, it is inlined as part of another step. It is also not obvious how to tell whether the setup was successful.

This sent me down a bit of a rabbit hole because several of the following steps fail in surprising ways (e.g. TLS errors) when the env variables are missing. I thought I had setup `direnv` correctly, but actually had missed a step.

This PR modifies the README to callout `task workstation:direnv` as a separate step and explains how to check whether it was successful. Hopefully this will will prevent someone else from going down the same rabbit hole. 😄 

P.S. `direnv` is really neat! I am going to start using it everywhere!