### PR TITLE
Clarify talos:bootstrap setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ You have two different options for setting up your local workstation.
     task talos:bootstrap
     ```
 
+2. ⚠️ It might take a while for the cluster to be setup (10+ minutes is normal), during which time you will see a variety of error messages like: "couldn't get current server API group list," "error: no matching resources found", etc. This is a normal. If this step gets interrupted, e.g. by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd>, you likely will need to [nuke the cluster](#-Nuke) before trying again.
+
 #### k3s
 
 1. Install Kubernetes depending on the distribution you chose


### PR DESCRIPTION
I ran into two issues while running to bootstrap my Talos cluster:

1. The cluster was left in a partially-initialized, non-functional state after running the command without the required environment variables were not set (see also: #1437).
2. After fixing that issue, I assumed that all of the permission errors spam indicated that something was still wrong - so I <kbd>Ctrl</kbd> + <kbd>C</kbd>ed the process after a few minutes. 

This PR adds a note to the README that the `talos:bootstrap` command (1) may take a while, (2) outputs a bunch of error messages, and (3) may require nuking the cluster if interrupted.