### PR TITLE
chore: migrate to new openebs chart repository

### DIFF
--- a/bootstrap/templates/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml.j2
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: openebs
-      version: 3.10.0
+      version: 4.0.1
       sourceRef:
         kind: HelmRepository
         name: openebs
@@ -21,14 +21,23 @@ spec:
     remediation:
       retries: 3
   values:
-    ndm:
-      enabled: false
-    ndmOperator:
-      enabled: false
-    localprovisioner:
-      enabled: true
-      deviceClass:
-        enabled: false
+    engines:
+      local:
+        lvm:
+          enabled: false
+        zfs:
+          enabled: false
+      replicated:
+        mayastor:
+          enabled: false
+    openebs-crds:
+      csi:
+        volumeSnapshots:
+          enabled: false
+    localpv-provisioner:
+      localpv:
+        image:
+          registry: quay.io/
       hostpathClass:
         enabled: true
         name: openebs-hostpath

--- a/bootstrap/templates/kubernetes/flux/repositories/helm/openebs.yaml.j2
+++ b/bootstrap/templates/kubernetes/flux/repositories/helm/openebs.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h
-  url: https://openebs.github.io/charts
+  url: https://openebs.github.io/openebs


### PR DESCRIPTION
The old chart repository was archived eagerly a couple of days ago, which broke things for a lot of people. They reinstated the repository now, but added a deprecation notice to it.

This change switches openebs to the new chart repo. Since this does not contain release for the 3.x branch anymore, I did the necessary values changes to bump openebs to 4.x.

With the new values, it will only deploy the localpv-provisioner, just like we did on version 3.x.

I'm using 4.x already since a couple of days and it's working as intended (https://github.com/martinohmann/home-ops/blob/main/kubernetes/main/apps/openebs-system/openebs/app/helmrelease.yaml).