### PR TITLE
chore: update kube-vip

### DIFF
--- a/bootstrap/templates/partials/kube-vip-ds.partial.yaml.j2
+++ b/bootstrap/templates/partials/kube-vip-ds.partial.yaml.j2
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: kube-vip
-          image: ghcr.io/kube-vip/kube-vip:v0.7.1
+          image: ghcr.io/kube-vip/kube-vip:v0.8.0
           imagePullPolicy: IfNotPresent
           args: ["manager"]
           env:


### PR DESCRIPTION
Should we add: `# renovate: datasource=github-releases depName=kube-vip/kube-vip`?