### PR TITLE
fix helmfile for prometheus-operator-crds dependsOn and Taskfile talos:nuke error

### DIFF
--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -79,7 +79,7 @@ tasks:
     desc: Resets nodes back to maintenance mode
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     dir: "{{.TALOS_DIR}}"
-    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }}--system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
+    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
 
   .reset:
     internal: true

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -22,22 +22,22 @@ releases:
     chart: cilium/cilium
     version: 1.15.5
     values: ["../../../apps/kube-system/cilium/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds"]
+    needs: ["observability/prometheus-operator-crds"]
   - name: coredns
     namespace: kube-system
     chart: coredns/coredns
     version: 1.29.0
     values: ["../../../apps/kube-system/coredns/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium"]
+    needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver
     version: 1.2.1
     values: ["../../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
     version: v0.0.22
     values: ["../../../apps/kube-system/spegel/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]


### PR DESCRIPTION
helmfile error
`in /Users/hz323328/Personal/cluster-template/kubernetes/bootstrap/talos/helmfile.yaml: release(s) "kube-system/cilium", "kube-system/coredns", "kube-system/kubelet-csr-approver", "kube-system/spegel" depend(s) on an undefined release "kube-system/prometheus-operator-crds". Perhaps you made a typo in "needs" or forgot defining a release named "prometheus-operator-crds" with appropriate "namespace" and "kubeContext"?
`
Taskfile error
```
task talos:nuke 
error:
unknown flag: --reboot--system-labels-to-wipe

Usage:
  talosctl reset [flags]

Flags:
      --debug                                    debug operation from kernel logs. --wait is set to true when this flag is set
      --graceful                                 if true, attempt to cordon/drain node and leave etcd (if applicable) (default true)
  -h, --help                                     help for reset
      --insecure                                 reset using the insecure (encrypted with no auth) maintenance service
      --reboot                                   if true, reboot the node after resetting instead of shutting down
      --system-labels-to-wipe strings            if set, just wipe selected system disk partitions by label but keep other partitions intact
      --timeout duration                         time to wait for the operation is complete if --debug or --wait is set (default 30m0s)
      --user-disks-to-wipe strings               if set, wipes defined devices in the list
      --wait                                     wait for the operation to complete, tracking its progress. always set to true when --debug is set (default true)
      --wipe-mode all, system-disk, user-disks   disk reset mode (default all)

Global Flags:
      --cluster string       Cluster to connect to if a proxy endpoint is used.
      --context string       Context to be used in command
  -e, --endpoints strings    override default endpoints in Talos configuration
  -n, --nodes strings        target the specified nodes
      --talosconfig string   The path to the Talos configuration file. Defaults to 'TALOSCONFIG' env variable if set, otherwise '$HOME/.talos/config' and '/var/run/secrets/talos.dev/config' in order.
```