### PR TITLE
Fix helmvalue path

### DIFF
--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -79,7 +79,7 @@ tasks:
     desc: Resets nodes back to maintenance mode
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     dir: "{{.TALOS_DIR}}"
-    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }}--system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
+    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
 
   .reset:
     internal: true

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -21,23 +21,23 @@ releases:
     namespace: kube-system
     chart: cilium/cilium
     version: 1.15.5
-    values: ["../../../apps/kube-system/cilium/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/cilium/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds"]
   - name: coredns
     namespace: kube-system
     chart: coredns/coredns
     version: 1.29.0
-    values: ["../../../apps/kube-system/coredns/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/coredns/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver
     version: 1.2.1
-    values: ["../../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
     version: v0.0.22
-    values: ["../../../apps/kube-system/spegel/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/spegel/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -22,22 +22,22 @@ releases:
     chart: cilium/cilium
     version: 1.15.5
     values: ["../../../apps/kube-system/cilium/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds"]
+    needs: ["observability/prometheus-operator-crds"]
   - name: coredns
     namespace: kube-system
     chart: coredns/coredns
     version: 1.29.0
     values: ["../../../apps/kube-system/coredns/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium"]
+    needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver
     version: 1.2.1
     values: ["../../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
     version: v0.0.22
     values: ["../../../apps/kube-system/spegel/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]


### PR DESCRIPTION
`Comparing release=prometheus-operator-crds, chart=/var/folders/w2/dpq8tgkd3rdbmdw3w52vwdw40000gp/T/helmfile773241121/observability/prometheus-operator-crds/prometheus-operator-crds/11.0.0/prometheus-operator-crds
in /Users/hz323328/Personal/cluster-template/kubernetes/bootstrap/talos/helmfile.yaml: failed processing release cilium: values file matching "../../../../apps/kube-system/cilium/app/helm-values.yaml" does not exist in "."`