### PR TITLE
Remove core dns

### DIFF
--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -79,7 +79,7 @@ tasks:
     desc: Resets nodes back to maintenance mode
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     dir: "{{.TALOS_DIR}}"
-    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }}--system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
+    cmd: talhelper gencommand reset --extra-flags "--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
 
   .reset:
     internal: true

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -21,23 +21,23 @@ releases:
     namespace: kube-system
     chart: cilium/cilium
     version: 1.15.5
-    values: ["../../../apps/kube-system/cilium/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/cilium/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds"]
   - name: coredns
     namespace: kube-system
     chart: coredns/coredns
     version: 1.29.0
-    values: ["../../../apps/kube-system/coredns/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/coredns/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver
     version: 1.2.1
-    values: ["../../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
     version: v0.0.22
-    values: ["../../../apps/kube-system/spegel/app/helm-values.yaml"]
+    values: ["../../apps/kube-system/spegel/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -22,22 +22,22 @@ releases:
     chart: cilium/cilium
     version: 1.15.5
     values: ["../../../apps/kube-system/cilium/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds"]
+    needs: ["observability/prometheus-operator-crds"]
   - name: coredns
     namespace: kube-system
     chart: coredns/coredns
     version: 1.29.0
     values: ["../../../apps/kube-system/coredns/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium"]
+    needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver
     version: 1.2.1
     values: ["../../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
   - name: spegel
     namespace: kube-system
     chart: oci://ghcr.io/spegel-org/helm-charts/spegel
     version: v0.0.22
     values: ["../../../apps/kube-system/spegel/app/helm-values.yaml"]
-    needs: ["prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]
+    needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]

--- a/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/helmfile.yaml.j2
@@ -23,12 +23,6 @@ releases:
     version: 1.15.5
     values: ["../../apps/kube-system/cilium/app/helm-values.yaml"]
     needs: ["observability/prometheus-operator-crds"]
-  - name: coredns
-    namespace: kube-system
-    chart: coredns/coredns
-    version: 1.29.0
-    values: ["../../apps/kube-system/coredns/app/helm-values.yaml"]
-    needs: ["observability/prometheus-operator-crds", "cilium"]
   - name: kubelet-csr-approver
     namespace: kube-system
     chart: postfinance/kubelet-csr-approver


### PR DESCRIPTION
By default coredns is enable in talos 1.7.2, we can remove this from helmfile
when install coredns using helmfile 
```
Release "coredns" does not exist. Installing it now.
  Error: Unable to continue with install: ServiceAccount "coredns" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "coredns"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
 STDERR:
  Error: Unable to continue with install: Deployment "coredns" in namespace "kube-system" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "coredns"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "kube-system"
  and more error
```

solution for this 
```
repositories:
  - name: cilium
    url: https://helm.cilium.io
  - name: postfinance
    url: https://postfinance.github.io/kubelet-csr-approver
  - name: coredns
    url: https://coredns.github.io/helm

helmDefaults:
  wait: true
  waitForJobs: true
  timeout: 600
  force: true

releases:
  - name: prometheus-operator-crds
    namespace: observability
    chart: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds
    version: 11.0.0
  - name: cilium
    namespace: kube-system
    chart: cilium/cilium
    version: 1.15.5
    values: ["../../apps/kube-system/cilium/app/helm-values.yaml"]
    needs: ["observability/prometheus-operator-crds"]
  - name: coredns
    namespace: kube-system
    chart: coredns/coredns
    version: 1.29.0
    values: ["../../apps/kube-system/coredns/app/helm-values.yaml"]
    needs: ["observability/prometheus-operator-crds", "cilium"]
    hooks:
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "serviceaccount"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-name=coredns"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "serviceaccount"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-namespace=kube-system"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "label"
        - "serviceaccount"
        - "coredns"
        - "-n"
        - "kube-system"
        - "app.kubernetes.io/managed-by=Helm"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "deployment"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-name=coredns"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "deployment"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-namespace=kube-system"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "label"
        - "deployment"
        - "coredns"
        - "-n"
        - "kube-system"
        - "app.kubernetes.io/managed-by=Helm"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "configmap"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-name=coredns"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "configmap"
        - "coredns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-namespace=kube-system"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "label"
        - "configmap"
        - "coredns"
        - "-n"
        - "kube-system"
        - "app.kubernetes.io/managed-by=Helm"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "service"
        - "kube-dns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-name=coredns"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "annotate"
        - "service"
        - "kube-dns"
        - "-n"
        - "kube-system"
        - "meta.helm.sh/release-namespace=kube-system"
        - "--overwrite"
    - events: ["prepare"]
      command: "kubectl"
      args:
        - "label"
        - "service"
        - "kube-dns"
        - "-n"
        - "kube-system"
        - "app.kubernetes.io/managed-by=Helm"
        - "--overwrite"
  - name: kubelet-csr-approver
    namespace: kube-system
    chart: postfinance/kubelet-csr-approver
    version: 1.2.1
    values: ["../../apps/kube-system/kubelet-csr-approver/app/helm-values.yaml"]
    needs: ["observability/prometheus-operator-crds", "cilium", "coredns"]
  - name: spegel
    namespace: kube-system
    chart: oci://ghcr.io/spegel-org/helm-charts/spegel
    version: v0.0.22
    values: ["../../apps/kube-system/spegel/app/helm-values.yaml"]
    needs: ["observability/prometheus-operator-crds", "cilium", "coredns", "kubelet-csr-approver"]

```