### PR TITLE
Allow extraManifests to be specified

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -86,6 +86,12 @@ nodes:
     patches:
       - "@./patches/node_#{ item.name }#.yaml"
     #% endif %#
+    #% if item.manifests %#
+    extraManifests:
+      #% for manifest in item.manifests %#
+      - #{ manifest }#
+      #% endfor %#
+    #% endif %#
   #% endfor %#
 
 patches:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -24,6 +24,8 @@ bootstrap_node_inventory: []
     #   mac_addr: ""      # (Required) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
     #   schematic_id: ""  # (Optional) Override the 'bootstrap_schematic_id' with a node specific schematic ID from https://factory.talos.dev/
     #   mtu: ""           # (Optional) MTU for the NIC, default is 1500
+    #   manifests:        # (Optional) Additional manifests to include after MachineConfig
+    #     - extra.yaml    #            See: https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/
     # ...
 
 # (Optional) The DNS servers to use for the cluster nodes.


### PR DESCRIPTION
Talos v1.7 now requires [ExtensionServiceConfig's](https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/) defined for configuring [System Extensions](https://www.talos.dev/v1.7/talos-guides/configuration/system-extensions/) (ex. nut-config). Talhelper added support for these in https://github.com/budimanjojo/talhelper/pull/431, but including these in `config.yaml` looks like it could get pretty messy.

The node.extraManifests object supports including external files and works for including these needed configs. This patch adds parsing of the bootstrap_node_inventory[].manifests key to allow these to be included.

Example `config.yaml`
```
bootstrap_node_inventory:
  - name: node1
...
    manifests:
      - manifests/nut-config.yaml
```
Results in:
```
$ talhelper genconfig -dn
...
+++ b/.../home-kubernetes-node1.yaml
...
   allowSchedulingOnControlPlanes: true
+---
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: nut-client
+configFiles:
+  - content: |-
+        MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave                                                                                                              +        SHUTDOWNCMD "/sbin/poweroff"
+    mountPath: /usr/local/etc/nut/upsmon.conf
```
with the `manifests/nut-config.yaml` content of:
```
apiVersion: v1alpha1
kind: ExtensionServiceConfig
name: nut-client
configFiles:
  - content: |-
        MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
        SHUTDOWNCMD "/sbin/poweroff"
    mountPath: /usr/local/etc/nut/upsmon.conf
```