### PR TITLE
Allow extensionServices to be specified

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -92,6 +92,24 @@ nodes:
       - #{ manifest }#
       #% endfor %#
     #% endif %#
+    #% if item.extension_services %#
+    extensionServices:
+      #% for es in item.extension_services %#
+      - name: #{ es.name }#
+        configFiles:
+        #% for cf in es.configFiles %#
+          - content: |-
+              #{ cf.content }#
+            mountPath: #{ cf.mountPath }#
+        #% endfor %#
+        #% if es.environment %#
+        environment:
+          #% for env in es.environment %#
+          - #{ env }#
+          #% endfor %#
+        #% endif %#
+      #% endfor %#
+    #% endif %#
   #% endfor %#
 
 patches:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -17,15 +17,23 @@ bootstrap_node_network: ""
 # (Required) Use only 1, 3 or more ODD number of controller nodes, recommended is 3
 #   Worker nodes are optional
 bootstrap_node_inventory: []
-    # - name: ""          # (Required) Name of the node (must match [a-z0-9-\]+)
-    #   address: ""       # (Optional) IP address of the node (Remove if node has a static DHCP reservation)
-    #   controller: true  # (Required) Set to true if this is a controller node
-    #   disk: ""          # (Required) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
-    #   mac_addr: ""      # (Required) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
-    #   schematic_id: ""  # (Optional) Override the 'bootstrap_schematic_id' with a node specific schematic ID from https://factory.talos.dev/
-    #   mtu: ""           # (Optional) MTU for the NIC, default is 1500
-    #   manifests:        # (Optional) Additional manifests to include after MachineConfig
-    #     - extra.yaml    #            See: https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/
+    # - name: ""            # (Required) Name of the node (must match [a-z0-9-\]+)
+    #   address: ""         # (Optional) IP address of the node (Remove if node has a static DHCP reservation)
+    #   controller: true    # (Required) Set to true if this is a controller node
+    #   disk: ""            # (Required) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
+    #   mac_addr: ""        # (Required) MAC address of the NIC for this node (talosctl get links -n <ip> --insecure)
+    #   schematic_id: ""    # (Optional) Override the 'bootstrap_schematic_id' with a node specific schematic ID from https://factory.talos.dev/
+    #   mtu: ""             # (Optional) MTU for the NIC, default is 1500
+    #   manifests:          # (Optional) Additional manifests to include after MachineConfig
+    #     - extra.yaml      #            See: https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/
+    #   extension_services: # (Optional) Additional talhelper ExtensionServices (supports talenv.sops.yaml envsubst)
+    #     - name: name
+    #       configFiles:
+    #         - content: |-
+    #             ...
+    #       mountPath: ...
+    #       environment:
+    #         - key=value
     # ...
 
 # (Optional) The DNS servers to use for the cluster nodes.


### PR DESCRIPTION
Similar to #1495 (which didn't support talenv.sops.yaml envsubst), this adds further support for https://github.com/budimanjojo/talhelper/pull/431. With talenv envsubst, secrets can be encrypted, and automatically referenced when `talhelper genconfig` is ran. This patch adds support for talhelper's extensionServices inclusions.

extraManifests is still useful for adding manifests like v1.7's [WatchdogTimerConfig](https://www.talos.dev/v1.7/reference/configuration/runtime/watchdogtimerconfig/). 

Example `config.yaml`
```
bootstrap_node_inventory:
  - name: node1
...
    extension_services:
      - name: nut-client
        configFiles:
          - content: MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
            mountPath: /usr/local/etc/nut/upsmon.conf
        environment:
          - UPS_NAME=ups
```
Results in `talconfig.yaml`
```
nodes:
  - hostname: "node1"
...
    extensionServices:
      - name: nut-client
        configFiles:
          - content: |-
              MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
            mountPath: /usr/local/etc/nut/upsmon.conf
        environment:
          - UPS_NAME=ups
```
When supplied with the `talenv.sops.yaml` contents:
```
upsmonHost: 192.168.1.10
upsmonPasswd: password
upsmonPort: 3493
upsmonUpsName: ups
upsmonUser: username
```
Renders clusterconfig files with:
```
version: v1alpha1
...
  network:
    hostname: node1
...
  allowSchedulingOnControlPlanes: true
---
apiVersion: v1alpha1
kind: ExtensionServiceConfig
name: nut-client
configFiles:
  - content: MONITOR ups@192.168.1.10:3493 1 username password slave
    mountPath: /usr/local/etc/nut/upsmon.conf
environment:
  - UPS_NAME=ups
```