### PR TITLE
Fix extensionServices configFile content multi-line indentation.

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -99,7 +99,7 @@ nodes:
         configFiles:
         #% for cf in es.configFiles %#
           - content: |-
-              #{ cf.content }#
+#{ cf.content }#
             mountPath: #{ cf.mountPath }#
         #% endfor %#
         #% if es.environment %#


### PR DESCRIPTION
Related to #1496. The first line of rendered extensionServices configFile content strings was not being indented correctly. Simple patch to correct formatting.