### PR TITLE
Fix extensionServices configFile content multi-line indentation.

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -99,7 +99,7 @@ nodes:
         configFiles:
         #% for cf in es.configFiles %#
           - content: |-
-#{ cf.content }#
+              #{ cf.content | indent(14, yes) }#
             mountPath: #{ cf.mountPath }#
         #% endfor %#
         #% if es.environment %#


### PR DESCRIPTION
Fix for #1497.
This one properly renders multi-line content entries...
```
+    extensionServices:
+      - name: nut-client
+        configFiles:
+          - content: |-
+              MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
+              SHUTDOWNCMD "/sbin/poweroff"
+            mountPath: /usr/local/etc/nut/upsmon.conf
```
