### PR TITLE
Sort talos patches for consistency

### DIFF
--- a/bootstrap/scripts/plugin.py
+++ b/bootstrap/scripts/plugin.py
@@ -21,7 +21,7 @@ def talos_patches(value: str) -> list[str]:
     path = Path(f'bootstrap/templates/kubernetes/bootstrap/talos/patches/{value}')
     if not path.is_dir():
         return []
-    return [str(f) for f in path.glob('*.yaml.j2') if f.is_file()]
+    return [str(f) for f in sorted(path.glob('*.yaml.j2')) if f.is_file()]
 
 
 # Return the nth host in a CIDR range


### PR DESCRIPTION
#1509 generates patch file inclusions into the talconfig.yaml, but doesn't sort them. For better IaC adherence, its ideal to keep the lists generated consistent over multiple `task configure` runs by sorting it.

Example patches before, note the `##-` prefixed patches (order dependent patches here) not getting applied in the correct order. All order dependent patches for a section could be forced into a single file, but this allows them to be safely separated and ordered by name.
```
+    - "@./patches/controller/01-network-deviceSelector.yaml"
+    - "@./patches/controller/02-network-mtu.yaml"
+    - "@./patches/controller/cluster.yaml"
+    - "@./patches/controller/04-tpm-disk-encryption.yaml"
+    - "@./patches/controller/api-access.yaml"
+    - "@./patches/controller/etcd.yaml"
+    - "@./patches/controller/03-network-dhcp.yaml"
+    - "@./patches/controller/disable-admission-controller.yaml"
```
After this patch:
```
+    - "@./patches/controller/01-network-deviceSelector.yaml"
+    - "@./patches/controller/02-network-mtu.yaml"
+    - "@./patches/controller/03-network-dhcp.yaml"
+    - "@./patches/controller/04-tpm-disk-encryption.yaml"
+    - "@./patches/controller/api-access.yaml"
+    - "@./patches/controller/cluster.yaml"
+    - "@./patches/controller/disable-admission-controller.yaml"
+    - "@./patches/controller/etcd.yaml"
```