### PR TITLE
Update README.md with additional GitHub webhook setup instructions as…

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ By default Flux will periodically check your git repository for changes. In orde
     https://flux-webhook.${bootstrap_cloudflare.domain}/hook/12ebd1e363c641dc3c2e430ecf3cee2b3c7a5ac9e1234506f6f5f3ce1230e123
     ```
 
-3. Navigate to the settings of your repository on Github, under "Settings/Webhooks" press the "Add webhook" button. Fill in the webhook url and your `bootstrap_github_webhook_token` secret and save.
+3. Navigate to the settings of your repository on Github, under "Settings/Webhooks" press the "Add webhook" button. Fill in the webhook URL and your bootstrap_github_webhook_token secret in config.yaml, Content type: application/json, Events: Choose Just the push event, and save.
 
 ## 💥 Nuke
 


### PR DESCRIPTION
… application/json isn't the default when creating a webhook.