### PR TITLE
Various Improvements

### DIFF
--- a/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
@@ -21,7 +21,9 @@ spec:
     remediation:
       retries: 3
   values:
-    installCRDs: true
+    crds:
+      enabled: true
+      keep: true
     dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
     dns01RecursiveNameserversOnly: true
     prometheus:

--- a/bootstrap/templates/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml.j2
@@ -29,7 +29,7 @@ spec:
       service:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: "external.${SECRET_DOMAIN}"
-          io.cilium/lb-ipam-ips: "#{ bootstrap_cloudflare.tunnel.ingress_vip }#"
+          lbipam.cilium.io/ips: "#{ bootstrap_cloudflare.tunnel.ingress_vip }#"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: external

--- a/bootstrap/templates/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml.j2
@@ -26,7 +26,7 @@ spec:
     controller:
       service:
         annotations:
-          io.cilium/lb-ipam-ips: "#{ bootstrap_cloudflare.ingress_vip }#"
+          lbipam.cilium.io/ips: "#{ bootstrap_cloudflare.ingress_vip }#"
         externalTrafficPolicy: Cluster
       ingressClassResource:
         name: internal

--- a/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/network/k8s-gateway/app/helmrelease.yaml.j2
@@ -28,6 +28,6 @@ spec:
       type: LoadBalancer
       port: 53
       annotations:
-        io.cilium/lb-ipam-ips: "#{ bootstrap_cloudflare.gateway_vip }#"
+        lbipam.cilium.io/ips: "#{ bootstrap_cloudflare.gateway_vip }#"
       externalTrafficPolicy: Cluster
     watchedResources: ["Ingress", "Service"]

--- a/bootstrap/templates/kubernetes/bootstrap/talos/patches/global/sysctl.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/patches/global/sysctl.yaml.j2
@@ -3,5 +3,5 @@ machine:
     fs.inotify.max_queued_events: "65536"
     fs.inotify.max_user_watches: "524288"
     fs.inotify.max_user_instances: "8192"
-    net.core.rmem_max: "2500000"
-    net.core.wmem_max: "2500000"
+    net.core.rmem_max: "7500000"
+    net.core.wmem_max: "7500000"


### PR DESCRIPTION
## Cert-Manager
Replaced deprecated 
```yaml
installCRDs: true
``` 
with the equivalent:
```yaml
crds:
  enabled: true
  keep: true
```
[Default Helm Chart Values](https://artifacthub.io/packages/helm/cert-manager/cert-manager?modal=values&path=installCRDs)

## Cilium
Updated the deprecated load balancer annotation key:
```yaml
io.cilium/lb-ipam-ips
```
to:
```yaml
lbipam.cilium.io/ips
```
[IP Requesting Documentation](https://docs.cilium.io/en/stable/network/lb-ipam/#requesting-ips)

## Sysctl/Cloudflared
Cloudflared uses QUIC UDP, triggering a log warning about insufficient buffer size. Increasing the buffer to `7500000` resolves this issue, as per the recommendation:
[UDP QUIC Buffer Documentation](https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes)
