### PR TITLE
Fix 'xargs: command line too long' in SOPS encryption task

### DIFF
--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -13,6 +13,14 @@ tasks:
     desc: Encrypt all Kubernetes SOPS secrets
     cmds:
       - cmd: |
+          if [ ! -f {{.SOPS_CONFIG_FILE}} ]; then
+            echo "Missing Sops config file"
+            exit 1
+          fi
+          if [ ! -f {{.AGE_FILE}} ]; then
+            echo "Missing Sops Age key file"
+            exit 1
+          fi
           find "{{.KUBERNETES_DIR}}" -type f -name "*.sops.*" | while read -r file; do
             if sops filestatus "$file" | jq --exit-status ".encrypted == false" > /dev/null; then
               sops --encrypt --in-place "$file"

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -20,7 +20,7 @@ tasks:
             fi
           done
     preconditions:
-      - msg: Missing Sops config
+      - msg: Missing Sops config file
         sh: test -f {{.SOPS_CONFIG_FILE}}
       - msg: Missing Sops Age key file
         sh: test -f {{.AGE_FILE}}

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -13,20 +13,17 @@ tasks:
     desc: Encrypt all Kubernetes SOPS secrets
     cmds:
       - cmd: |
-          if [ ! -f {{.SOPS_CONFIG_FILE}} ]; then
-            echo "Missing Sops config file"
-            exit 1
-          fi
-          if [ ! -f {{.AGE_FILE}} ]; then
-            echo "Missing Sops Age key file"
-            exit 1
-          fi
           find "{{.KUBERNETES_DIR}}" -type f -name "*.sops.*" | while read -r file; do
             if sops filestatus "$file" | jq --exit-status ".encrypted == false" > /dev/null; then
               sops --encrypt --in-place "$file"
               echo "Encrypted $file"
             fi
           done
+    preconditions:
+      - msg: Missing Sops config
+        sh: test -f {{.SOPS_CONFIG_FILE}}
+      - msg: Missing Sops Age key file
+        sh: test -f {{.AGE_FILE}}
 
   .reset:
     internal: true

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -12,24 +12,13 @@ tasks:
   encrypt:
     desc: Encrypt all Kubernetes SOPS secrets
     cmds:
-      - for: { var: file }
-        task: .encrypt-file
-        vars:
-          file: "{{.ITEM}}"
-    vars:
-      file:
-        sh: find "{{.KUBERNETES_DIR}}" -type f -name "*.sops.*" | xargs -I {} sh -c 'sops filestatus {} | jq --exit-status ".encrypted == false" > /dev/null && echo {}'
-
-  .encrypt-file:
-    internal: true
-    cmd: sops --encrypt --in-place {{.file}}
-    requires:
-      vars: ["file"]
-    preconditions:
-      - msg: Missing Sops config file
-        sh: test -f {{.SOPS_CONFIG_FILE}}
-      - msg: Missing Sops Age key file
-        sh: test -f {{.AGE_FILE}}
+      - cmd: |
+          find "{{.KUBERNETES_DIR}}" -type f -name "*.sops.*" | while read -r file; do
+            if sops filestatus "$file" | jq --exit-status ".encrypted == false" > /dev/null; then
+              sops --encrypt --in-place "$file"
+              echo "Encrypted $file"
+            fi
+          done
 
   .reset:
     internal: true


### PR DESCRIPTION
**Problem:**

The SOPS encryption task was failing with the error "command line too long" when processing many files using `xargs`. This happened because the number of files found by `find `exceeded the system's command-line length limit.

**Solution:**

- Replaced `xargs` with a `while read -r` loop to process each file individually, avoiding command length limits.

- Relocated existing precondition checks in the encryption task.

**Changes:**

- Added shell checks for the SOPS configuration and Age key file at the beginning of the encryption task.

- Replaced the `xargs` command with a while loop to handle file encryption without exceeding command-line length limitations.

This PR fixes the command line limit issue while retaining the original precondition checks to ensure all necessary files are present before encryption.