### PR TITLE
chore: update taskfiles and direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -9,3 +9,6 @@ export PYTHONDONTWRITEBYTECODE="1"
 export TALOSCONFIG="$(expand_path ./kubernetes/bootstrap/talos/clusterconfig/talosconfig)"
 # Bin
 PATH_add "$(expand_path ./.bin)"
+# Taskfile
+export TASK_X_ENV_PRECEDENCE=1
+export TASK_X_MAP_VARIABLES=0

--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -1,75 +1,71 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 vars:
-  CLUSTER_SECRET_SOPS_FILE: "{{.KUBERNETES_DIR}}/flux/vars/cluster-secrets.sops.yaml"
-  CLUSTER_SETTINGS_FILE: "{{.KUBERNETES_DIR}}/flux/vars/cluster-settings.yaml"
-  GITHUB_DEPLOY_KEY_FILE: "{{.KUBERNETES_DIR}}/bootstrap/flux/github-deploy-key.sops.yaml"
+  CLUSTER_SECRET_SOPS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-secrets.sops.yaml'
+  CLUSTER_SETTINGS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-settings.yaml'
+  GITHUB_DEPLOY_KEY_FILE: '{{.KUBERNETES_DIR}}/bootstrap/flux/github-deploy-key.sops.yaml'
 
 tasks:
 
   bootstrap:
     desc: Bootstrap Flux into a Kubernetes cluster
     cmds:
-      - kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --kustomize {{.KUBERNETES_DIR}}/bootstrap/flux
+      - kubectl apply --server-side --kustomize {{.KUBERNETES_DIR}}/bootstrap/flux
       - |
-        if ! kubectl --kubeconfig {{.KUBECONFIG_FILE}} -n flux-system get secret sops-age >/dev/null 2>&1; then
-          cat {{.AGE_FILE}} | kubectl --kubeconfig {{.KUBECONFIG_FILE}} -n flux-system create secret generic sops-age --from-file=age.agekey=/dev/stdin
+        if ! kubectl --namespace flux-system get secret sops-age >/dev/null 2>&1; then
+          cat {{.SOPS_AGE_KEY_FILE}} | kubectl --namespace flux-system create secret generic sops-age --from-file=age.agekey=/dev/stdin
         else
           echo "sops-age secret already exists, skipping creation."
         fi
-      - sops --decrypt {{.CLUSTER_SECRET_SOPS_FILE}} | kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --filename -
-      - kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --filename {{.CLUSTER_SETTINGS_FILE}}
-      - kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --kustomize {{.KUBERNETES_DIR}}/flux/config
+      - sops --decrypt {{.CLUSTER_SECRET_SOPS_FILE}} | kubectl apply --server-side --filename -
+      - kubectl apply --server-side --filename {{.CLUSTER_SETTINGS_FILE}}
+      - kubectl apply --server-side --kustomize {{.KUBERNETES_DIR}}/flux/config
     preconditions:
       - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG_FILE}}
+        sh: test -f {{.KUBECONFIG}}
       - msg: Missing Sops Age key file
-        sh: test -f {{.AGE_FILE}}
+        sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
-  apply:
-    desc: Apply a Flux Kustomization resource for a cluster
+  apply-ks:
+    desc: Apply a Flux Kustomization resource
     summary: |
-      Args:
-        path: Path under apps containing the Flux Kustomization resource (ks.yaml) (required)
-        ns: Namespace the Flux Kustomization exists in (default: flux-system)
+      PATH: Path to the Flux Kustomization resource from the apps base dir (required, e.g. default/plex)
+      NS: Namespace the Flux Kustomization exists in (default: flux-system)
     cmd: |
-      flux --kubeconfig {{.KUBECONFIG_FILE}} build ks $(basename {{.path}}) \
-          --namespace {{.ns}} \
-          --kustomization-file {{.KUBERNETES_DIR}}/apps/{{.path}}/ks.yaml \
-          --path {{.KUBERNETES_DIR}}/apps/{{.path}} \
-          {{- if contains "not found" .ks }}--dry-run \{{ end }}
+      flux build ks {{base .PATH}} \
+          --namespace {{.NS}} \
+          --kustomization-file {{.KUBERNETES_DIR}}/apps/{{.PATH}}/ks.yaml \
+          --path {{.KUBERNETES_DIR}}/apps/{{.PATH}} \
+          {{- if contains "not found" .KS }}--dry-run \{{ end }}
       | \
-      kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side \
-          --field-manager=kustomize-controller -f -
+      kubectl apply --server-side --field-manager=kustomize-controller -f -
     requires:
-      vars: ["path"]
+      vars: ['PATH']
     vars:
-      ns: '{{.ns | default "flux-system"}}'
-      ks:
-        sh: flux --kubeconfig {{.KUBECONFIG_FILE}} --namespace {{.ns}} get kustomizations $(basename {{.path}}) 2>&1
+      NS: '{{.NS | default "flux-system"}}'
+      KS:
+        sh: flux --namespace {{.NS}} get kustomizations {{base .PATH}} 2>&1
     preconditions:
-      - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG_FILE}}
       - msg: Missing Flux Kustomization for app {{.path}}
         sh: test -f {{.KUBERNETES_DIR}}/apps/{{.path}}/ks.yaml
 
   reconcile:
     desc: Force update Flux to pull in changes from your Git repository
-    cmd: flux --kubeconfig {{.KUBECONFIG_FILE}} reconcile --namespace flux-system kustomization cluster --with-source
+    cmd: flux reconcile --namespace flux-system kustomization cluster --with-source
     preconditions:
       - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG_FILE}}
+        sh: test -f {{.KUBECONFIG}}
 
   github-deploy-key:
     cmds:
-      - kubectl create namespace flux-system --dry-run=client -o yaml | kubectl --kubeconfig {{.KUBECONFIG_FILE}} apply --filename -
-      - sops --decrypt {{.GITHUB_DEPLOY_KEY_FILE}} | kubectl apply --kubeconfig {{.KUBECONFIG_FILE}} --server-side --filename -
+      - kubectl create namespace flux-system --dry-run=client -o yaml | kubectl apply --filename -
+      - sops --decrypt {{.GITHUB_DEPLOY_KEY_FILE}} | kubectl apply --server-side --filename -
     preconditions:
       - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG_FILE}}
+        sh: test -f {{.KUBECONFIG}}
       - msg: Missing Sops Age key file
-        sh: test -f {{.AGE_FILE}}
+        sh: test -f {{.SOPS_AGE_KEY_FILE}}
       - msg: Missing Github deploy key file
         sh: test -f {{.GITHUB_DEPLOY_KEY_FILE}}

--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -5,14 +5,14 @@ version: '3'
 vars:
   CLUSTER_SECRET_SOPS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-secrets.sops.yaml'
   CLUSTER_SETTINGS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-settings.yaml'
-  GITHUB_DEPLOY_KEY_FILE: '{{{{.KUBERNETES_DIR}}/bootstrap}}/flux/github-deploy-key.sops.yaml'
+  GITHUB_DEPLOY_KEY_FILE: '{{.KUBERNETES_DIR}}/bootstrap/flux/github-deploy-key.sops.yaml'
 
 tasks:
 
   bootstrap:
     desc: Bootstrap Flux into a Kubernetes cluster
     cmds:
-      - kubectl apply --server-side --kustomize {{{{.KUBERNETES_DIR}}/bootstrap}}/flux
+      - kubectl apply --server-side --kustomize {{.KUBERNETES_DIR}}/bootstrap/flux
       - |
         if ! kubectl --namespace flux-system get secret sops-age >/dev/null 2>&1; then
           cat {{.SOPS_AGE_KEY_FILE}} | kubectl --namespace flux-system create secret generic sops-age --from-file=age.agekey=/dev/stdin

--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -28,29 +28,6 @@ tasks:
       - msg: Missing Sops Age key file
         sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
-  apply-ks:
-    desc: Apply a Flux Kustomization resource
-    summary: |
-      PATH: Path to the Flux Kustomization resource from the apps base dir (required, e.g. default/plex)
-      NS: Namespace the Flux Kustomization exists in (default: flux-system)
-    cmd: |
-      flux build ks {{base .PATH}} \
-          --namespace {{.NS}} \
-          --kustomization-file {{.KUBERNETES_DIR}}/apps/{{.PATH}}/ks.yaml \
-          --path {{.KUBERNETES_DIR}}/apps/{{.PATH}} \
-          {{- if contains "not found" .KS }}--dry-run \{{ end }}
-      | \
-      kubectl apply --server-side --field-manager=kustomize-controller -f -
-    requires:
-      vars: ['PATH']
-    vars:
-      NS: '{{.NS | default "flux-system"}}'
-      KS:
-        sh: flux --namespace {{.NS}} get kustomizations {{base .PATH}} 2>&1
-    preconditions:
-      - msg: Missing Flux Kustomization for app {{.path}}
-        sh: test -f {{.KUBERNETES_DIR}}/apps/{{.path}}/ks.yaml
-
   reconcile:
     desc: Force update Flux to pull in changes from your Git repository
     cmd: flux reconcile --namespace flux-system kustomization cluster --with-source

--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -5,14 +5,14 @@ version: '3'
 vars:
   CLUSTER_SECRET_SOPS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-secrets.sops.yaml'
   CLUSTER_SETTINGS_FILE: '{{.KUBERNETES_DIR}}/flux/vars/cluster-settings.yaml'
-  GITHUB_DEPLOY_KEY_FILE: '{{.KUBERNETES_DIR}}/bootstrap/flux/github-deploy-key.sops.yaml'
+  GITHUB_DEPLOY_KEY_FILE: '{{{{.KUBERNETES_DIR}}/bootstrap}}/flux/github-deploy-key.sops.yaml'
 
 tasks:
 
   bootstrap:
     desc: Bootstrap Flux into a Kubernetes cluster
     cmds:
-      - kubectl apply --server-side --kustomize {{.KUBERNETES_DIR}}/bootstrap/flux
+      - kubectl apply --server-side --kustomize {{{{.KUBERNETES_DIR}}/bootstrap}}/flux
       - |
         if ! kubectl --namespace flux-system get secret sops-age >/dev/null 2>&1; then
           cat {{.SOPS_AGE_KEY_FILE}} | kubectl --namespace flux-system create secret generic sops-age --from-file=age.agekey=/dev/stdin

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 vars:
   KUBECONFORM_SCRIPT: "{{.SCRIPTS_DIR}}/kubeconform.sh"

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -31,6 +31,6 @@ tasks:
       - msg: Missing kubeconform script
         sh: test -f {{.KUBECONFORM_SCRIPT}}
 
-  .reset:
+  reset:
     internal: true
     cmd: rm -rf {{.KUBERNETES_DIR}}

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -10,10 +10,10 @@ tasks:
   resources:
     desc: Gather common resources in your cluster, useful when asking for support
     cmds:
-      - for: { var: resource }
+      - for: { var: RESOURCE }
         cmd: kubectl get {{.ITEM}} {{.CLI_ARGS | default "-A"}}
     vars:
-      resource: >-
+      RESOURCE: >-
         nodes
         gitrepositories
         kustomizations

--- a/.taskfiles/Repository/Taskfile.yaml
+++ b/.taskfiles/Repository/Taskfile.yaml
@@ -29,18 +29,13 @@ tasks:
         sh: test -f {{.ROOT_DIR}}/.github/renovate.json5
 
   reset:
-    desc: Reset templated configuration files
+    desc: Reset templated configuration files (use --force to reset repo back to HEAD)
     prompt: Reset templated configuration files... continue?
     cmds:
-      - task: :kubernetes:.reset
-      - task: :sops:.reset
-      - task: :talos:.reset
-
-  force-reset:
-    desc: Reset repo back to HEAD
-    prompt: Reset repo back to HEAD... continue?
-    cmds:
-      - task: reset
-      - git reset --hard HEAD
-      - git clean -f -d
-      - git pull origin main
+      - task: :kubernetes:reset
+      - task: :sops:reset
+      - task: :talos:reset
+      - cmd: |
+          {{- if eq .CLI_FORCE true }}
+          git reset --hard HEAD && git clean -f -d && git pull origin main
+          {{- end }}

--- a/.taskfiles/Repository/Taskfile.yaml
+++ b/.taskfiles/Repository/Taskfile.yaml
@@ -2,6 +2,9 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: '3'
 
+vars:
+  PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
+
 tasks:
 
   clean:

--- a/.taskfiles/Repository/Taskfile.yaml
+++ b/.taskfiles/Repository/Taskfile.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 tasks:
 

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -6,8 +6,9 @@ tasks:
 
   age-keygen:
     desc: Initialize Age Key for Sops
-    cmd: age-keygen --output {{.AGE_FILE}}
-    status: ["test -f {{.AGE_FILE}}"]
+    cmd: age-keygen --output {{.SOPS_AGE_KEY_FILE}}
+    status:
+      - test -f {{.SOPS_AGE_KEY_FILE}}
 
   encrypt:
     desc: Encrypt all Kubernetes SOPS secrets
@@ -16,14 +17,14 @@ tasks:
           find "{{.KUBERNETES_DIR}}" -type f -name "*.sops.*" | while read -r file; do
             if sops filestatus "$file" | jq --exit-status ".encrypted == false" > /dev/null; then
               sops --encrypt --in-place "$file"
-              echo "Encrypted $file"
+              echo "Encrypted ${file}"
             fi
           done
     preconditions:
       - msg: Missing Sops config file
         sh: test -f {{.SOPS_CONFIG_FILE}}
       - msg: Missing Sops Age key file
-        sh: test -f {{.AGE_FILE}}
+        sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
   .reset:
     internal: true

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -26,6 +26,6 @@ tasks:
       - msg: Missing Sops Age key file
         sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
-  .reset:
+  reset:
     internal: true
     cmd: rm -rf {{.SOPS_CONFIG_FILE}}

--- a/.taskfiles/Sops/Taskfile.yaml
+++ b/.taskfiles/Sops/Taskfile.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 tasks:
 

--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -1,22 +1,21 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 vars:
-  TALHELPER_CLUSTER_DIR: "{{.KUBERNETES_DIR}}/bootstrap/talos/clusterconfig"
-  TALHELPER_SECRET_FILE: "{{.KUBERNETES_DIR}}/bootstrap/talos/talsecret.sops.yaml"
-  TALHELPER_CONFIG_FILE: "{{.KUBERNETES_DIR}}/bootstrap/talos/talconfig.yaml"
-  HELMFILE_FILE: "{{.KUBERNETES_DIR}}/bootstrap/helmfile.yaml"
-  TALOSCONFIG_FILE: "{{.TALHELPER_CLUSTER_DIR}}/talosconfig"
+  TALHELPER_CLUSTER_DIR: '{{.KUBERNETES_DIR}}/bootstrap/talos/clusterconfig'
+  TALHELPER_SECRET_FILE: '{{.KUBERNETES_DIR}}/bootstrap/talos/talsecret.sops.yaml'
+  TALHELPER_CONFIG_FILE: '{{.KUBERNETES_DIR}}/bootstrap/talos/talconfig.yaml'
+  HELMFILE_FILE: '{{.KUBERNETES_DIR}}/bootstrap/helmfile.yaml'
 
 env:
-  TALOSCONFIG: "{{.TALOSCONFIG_FILE}}"
+  TALOSCONFIG: '{{.TALHELPER_CLUSTER_DIR}}/talosconfig'
 
 tasks:
 
   bootstrap:
     desc: Bootstrap the Talos cluster
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
     cmds:
       - |
         if [ ! -f "{{.TALHELPER_SECRET_FILE}}" ]; then
@@ -26,8 +25,8 @@ tasks:
       - talhelper genconfig --config-file {{.TALHELPER_CONFIG_FILE}} --secret-file {{.TALHELPER_SECRET_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}}
       - talhelper gencommand apply --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="--insecure" | bash
       - until talhelper gencommand bootstrap --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} | bash; do sleep 10; done
-      - task: fetch-kubeconfig
-      - task: install-helm-apps
+      - task: conf
+      - task: apps
       - talosctl health --server=false
     preconditions:
       - msg: Missing talhelper config file
@@ -35,42 +34,42 @@ tasks:
       - msg: Missing Sops config file
         sh: test -f {{.SOPS_CONFIG_FILE}}
       - msg: Missing Sops Age key file
-        sh: test -f {{.AGE_FILE}}
+        sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
-  fetch-kubeconfig:
+  conf:
     desc: Fetch kubeconfig
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
     cmd: until talhelper gencommand kubeconfig --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
     preconditions:
       - msg: Missing talhelper config file
         sh: test -f {{.TALHELPER_CONFIG_FILE}}
 
-  install-helm-apps:
+  apps:
     desc: Bootstrap core apps needed for Talos
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
     cmds:
-      - until kubectl --kubeconfig {{.KUBECONFIG_FILE}} wait --for=condition=Ready=False nodes --all --timeout=600s; do sleep 10; done
-      - helmfile --kubeconfig {{.KUBECONFIG_FILE}} --file {{.HELMFILE_FILE}} apply --skip-diff-on-install --suppress-diff
-      - until kubectl --kubeconfig {{.KUBECONFIG_FILE}} wait --for=condition=Ready nodes --all --timeout=600s; do sleep 10; done
+      - until kubectl wait --for=condition=Ready=False nodes --all --timeout=600s; do sleep 10; done
+      - helmfile --file {{.HELMFILE_FILE}} apply --skip-diff-on-install --suppress-diff
+      - until kubectl wait --for=condition=Ready nodes --all --timeout=600s; do sleep 10; done
     preconditions:
       - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG_FILE}}
+        sh: test -f {{.KUBECONFIG}}
       - msg: Missing helmfile
         sh: test -f {{.HELMFILE_FILE}}
 
   upgrade:
     desc: Upgrade Talos on a node
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
     cmds:
-      - talosctl --nodes {{.node}} upgrade --image {{.image}} --wait=true --timeout=10m --preserve=true --reboot-mode={{.mode}}
-      - talosctl --nodes {{.node}} health --wait-timeout=10m --server=false
+      - talosctl --nodes {{.NODE}} upgrade --image {{.IMAGE}} --wait=true --timeout=10m --preserve=true --reboot-mode={{.MODE}}
+      - talosctl --nodes {{.NODE}} health --wait-timeout=10m --server=false
     vars:
-      mode: '{{.mode | default "default"}}'
+      MODE: '{{.MODE | default "default"}}'
     requires:
-      vars: ["node", "image"]
+      vars: ['NODE', 'IMAGE']
     preconditions:
       - msg: Missing talosconfig
-        sh: test -f {{.TALOSCONFIG_FILE}}
+        sh: test -f {{.TALOSCONFIG}}
       - msg: Unable to retrieve Talos config
         sh: talosctl config info >/dev/null 2>&1
       - msg: Node not found
@@ -78,17 +77,17 @@ tasks:
 
   upgrade-k8s:
     desc: Upgrade Kubernetes across the cluster
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
-    cmd: talosctl --nodes {{.controller}} upgrade-k8s --to {{.to}}
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
+    cmd: talosctl --nodes {{.CONTROLLER}} upgrade-k8s --to {{.TO}}
     requires:
-      vars: ["controller", "to"]
+      vars: ['CONTROLLER', 'TO']
     preconditions:
       - msg: Missing talosconfig
-        sh: test -f {{.TALOSCONFIG_FILE}}
+        sh: test -f {{.TALOSCONFIG}}
       - msg: Unable to retrieve Talos config
         sh: talosctl config info >/dev/null 2>&1
       - msg: Node not found
-        sh: talosctl --nodes {{.controller}} get machineconfig >/dev/null 2>&1
+        sh: talosctl --nodes {{.CONTROLLER}} get machineconfig >/dev/null 2>&1
 
   nuke:
     desc: Resets nodes back to maintenance mode

--- a/.taskfiles/Talos/Taskfile.yaml
+++ b/.taskfiles/Talos/Taskfile.yaml
@@ -36,27 +36,6 @@ tasks:
       - msg: Missing Sops Age key file
         sh: test -f {{.SOPS_AGE_KEY_FILE}}
 
-  conf:
-    desc: Fetch kubeconfig
-    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
-    cmd: until talhelper gencommand kubeconfig --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
-    preconditions:
-      - msg: Missing talhelper config file
-        sh: test -f {{.TALHELPER_CONFIG_FILE}}
-
-  apps:
-    desc: Bootstrap core apps needed for Talos
-    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
-    cmds:
-      - until kubectl wait --for=condition=Ready=False nodes --all --timeout=600s; do sleep 10; done
-      - helmfile --file {{.HELMFILE_FILE}} apply --skip-diff-on-install --suppress-diff
-      - until kubectl wait --for=condition=Ready nodes --all --timeout=600s; do sleep 10; done
-    preconditions:
-      - msg: Missing kubeconfig
-        sh: test -f {{.KUBECONFIG}}
-      - msg: Missing helmfile
-        sh: test -f {{.HELMFILE_FILE}}
-
   upgrade:
     desc: Upgrade Talos on a node
     dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
@@ -95,6 +74,27 @@ tasks:
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     cmd: talhelper gencommand reset --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
 
-  .reset:
+  conf:
+    internal: true
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
+    cmd: until talhelper gencommand kubeconfig --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
+    preconditions:
+      - msg: Missing talhelper config file
+        sh: test -f {{.TALHELPER_CONFIG_FILE}}
+
+  apps:
+    internal: true
+    dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
+    cmds:
+      - until kubectl wait --for=condition=Ready=False nodes --all --timeout=600s; do sleep 10; done
+      - helmfile --file {{.HELMFILE_FILE}} apply --skip-diff-on-install --suppress-diff
+      - until kubectl wait --for=condition=Ready nodes --all --timeout=600s; do sleep 10; done
+    preconditions:
+      - msg: Missing kubeconfig
+        sh: test -f {{.KUBECONFIG}}
+      - msg: Missing helmfile
+        sh: test -f {{.HELMFILE_FILE}}
+
+  reset:
     internal: true
     cmd: rm -rf {{.TALHELPER_CLUSTER_DIR}} {{.TALHELPER_SECRET_FILE}} {{.TALHELPER_CONFIG_FILE}}

--- a/.taskfiles/Workstation/Taskfile.yaml
+++ b/.taskfiles/Workstation/Taskfile.yaml
@@ -1,11 +1,11 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 vars:
-  ARCHFILE: "{{.ROOT_DIR}}/.taskfiles/Workstation/Archfile"
-  BREWFILE: "{{.ROOT_DIR}}/.taskfiles/Workstation/Brewfile"
-  GENERIC_BIN_DIR: "{{.ROOT_DIR}}/.bin"
+  ARCHFILE: '{{.ROOT_DIR}}/.taskfiles/Workstation/Archfile'
+  BREWFILE: '{{.ROOT_DIR}}/.taskfiles/Workstation/Brewfile'
+  GENERIC_BIN_DIR: '{{.ROOT_DIR}}/.bin'
 
 tasks:
 
@@ -13,42 +13,46 @@ tasks:
     desc: Run direnv hooks
     cmd: direnv allow .
     status:
-      - "[[ $(direnv status --json | jq '.state.foundRC.allowed') == 0 ]]"
-      - "[[ $(direnv status --json | jq '.state.loadedRC.allowed') == 0 ]]"
+      - '[[ $(direnv status --json | jq ".state.foundRC.allowed") == 0 ]]'
+      - '[[ $(direnv status --json | jq ".state.loadedRC.allowed") == 0 ]]'
 
   venv:
     desc: Set up virtual environment
     cmds:
-      - "{{.PYTHON_BIN}} -m venv {{.VIRTUAL_ENV}}"
+      - '{{.PYTHON_BIN}} -m venv {{.VIRTUAL_ENV}}'
       - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade pip setuptools wheel'
       - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade --requirement "{{.PIP_REQUIREMENTS_FILE}}"'
     sources:
-      - "{{.PIP_REQUIREMENTS_FILE}}"
+      - '{{.PIP_REQUIREMENTS_FILE}}'
     generates:
-      - "{{.VIRTUAL_ENV}}/pyvenv.cfg"
+      - '{{.VIRTUAL_ENV}}/pyvenv.cfg'
     preconditions:
-      - { msg: "Missing Pip requirements file", sh: "test -f {{.PIP_REQUIREMENTS_FILE}}" }
+      - msg: Missing Pip requirements file
+        sh: test -f {{.PIP_REQUIREMENTS_FILE}}
 
   brew:
     desc: Install workstation dependencies with Brew
     cmd: brew bundle --file {{.BREWFILE}}
     preconditions:
-      - { msg: "Missing Homebrew", sh: "command -v brew" }
-      - { msg: "Missing Brewfile", sh: "test -f {{.BREWFILE}}" }
+      - msg: Missing Homebrew
+        sh: command -v brew
+      - msg: Missing Brewfile
+        sh: test -f {{.BREWFILE}}
 
   arch:
     desc: Install Arch workstation dependencies with Paru Or Yay
-    cmd: "{{.helper}} -Syu --needed --noconfirm --noprogressbar $(cat {{.ARCHFILE}} | xargs)"
+    cmd: '{{.PKGMGR}} -Syu --needed --noconfirm --noprogressbar $(cat {{.ARCHFILE}} | xargs)'
     vars:
-      helper:
-        sh: "command -v yay || command -v paru"
+      PKGMGR:
+        sh: command -v yay || command -v paru
     preconditions:
-      - { msg: "Missing Archfile", sh: "test -f {{.ARCHFILE}}" }
+      - msg: Missing Archfile
+        sh: test -f {{.ARCHFILE}}
 
   generic-linux:
     desc: Install CLI tools into the projects .bin directory using curl
-    dir: "{{.GENERIC_BIN_DIR}}"
-    platforms: ["linux/amd64", "linux/arm64"]
+    dir: '{{.GENERIC_BIN_DIR}}'
+    platforms: ['linux/amd64', 'linux/arm64']
     cmds:
       - for:
           - budimanjojo/talhelper?as=talhelper&type=script
@@ -64,8 +68,8 @@ tasks:
           - mikefarah/yq?as=yq&type=script
         cmd: curl -fsSL "https://i.jpillora.com/{{.ITEM}}" | bash
       - cmd: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-        platforms: ["linux/amd64"]
+        platforms: ['linux/amd64']
       - cmd: curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
-        platforms: ["linux/arm64"]
+        platforms: ['linux/arm64']
       - cmd: chmod +x kubectl
       - cmd: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | USE_SUDO="false" HELM_INSTALL_DIR="." bash

--- a/.taskfiles/Workstation/Taskfile.yaml
+++ b/.taskfiles/Workstation/Taskfile.yaml
@@ -6,6 +6,8 @@ vars:
   ARCHFILE: '{{.ROOT_DIR}}/.taskfiles/Workstation/Archfile'
   BREWFILE: '{{.ROOT_DIR}}/.taskfiles/Workstation/Brewfile'
   GENERIC_BIN_DIR: '{{.ROOT_DIR}}/.bin'
+  PIP_REQUIREMENTS_FILE: '{{.ROOT_DIR}}/requirements.txt'
+  PYTHON_BIN: python3
 
 tasks:
 

--- a/.taskfiles/Workstation/Taskfile.yaml
+++ b/.taskfiles/Workstation/Taskfile.yaml
@@ -11,36 +11,6 @@ vars:
 
 tasks:
 
-  direnv:
-    desc: Run direnv hooks
-    cmd: direnv allow .
-    status:
-      - '[[ $(direnv status --json | jq ".state.foundRC.allowed") == 0 ]]'
-      - '[[ $(direnv status --json | jq ".state.loadedRC.allowed") == 0 ]]'
-
-  venv:
-    desc: Set up virtual environment
-    cmds:
-      - '{{.PYTHON_BIN}} -m venv {{.VIRTUAL_ENV}}'
-      - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade pip setuptools wheel'
-      - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade --requirement "{{.PIP_REQUIREMENTS_FILE}}"'
-    sources:
-      - '{{.PIP_REQUIREMENTS_FILE}}'
-    generates:
-      - '{{.VIRTUAL_ENV}}/pyvenv.cfg'
-    preconditions:
-      - msg: Missing Pip requirements file
-        sh: test -f {{.PIP_REQUIREMENTS_FILE}}
-
-  brew:
-    desc: Install workstation dependencies with Brew
-    cmd: brew bundle --file {{.BREWFILE}}
-    preconditions:
-      - msg: Missing Homebrew
-        sh: command -v brew
-      - msg: Missing Brewfile
-        sh: test -f {{.BREWFILE}}
-
   arch:
     desc: Install Arch workstation dependencies with Paru Or Yay
     cmd: '{{.PKGMGR}} -Syu --needed --noconfirm --noprogressbar $(cat {{.ARCHFILE}} | xargs)'
@@ -51,8 +21,24 @@ tasks:
       - msg: Missing Archfile
         sh: test -f {{.ARCHFILE}}
 
+  brew:
+    desc: Install workstation dependencies with Brew
+    cmd: brew bundle --file {{.BREWFILE}}
+    preconditions:
+      - msg: Missing Homebrew
+        sh: command -v brew
+      - msg: Missing Brewfile
+        sh: test -f {{.BREWFILE}}
+
+  direnv:
+    desc: Run direnv hooks
+    cmd: direnv allow .
+    status:
+      - '[[ $(direnv status --json | jq ".state.foundRC.allowed") == 0 ]]'
+      - '[[ $(direnv status --json | jq ".state.loadedRC.allowed") == 0 ]]'
+
   generic-linux:
-    desc: Install CLI tools into the projects .bin directory using curl
+    desc: Try to install CLI tools into the projects .bin directory
     dir: '{{.GENERIC_BIN_DIR}}'
     platforms: ['linux/amd64', 'linux/arm64']
     cmds:
@@ -75,3 +61,17 @@ tasks:
         platforms: ['linux/arm64']
       - cmd: chmod +x kubectl
       - cmd: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | USE_SUDO="false" HELM_INSTALL_DIR="." bash
+
+  venv:
+    desc: Set up virtual environment
+    cmds:
+      - '{{.PYTHON_BIN}} -m venv {{.VIRTUAL_ENV}}'
+      - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade pip setuptools wheel'
+      - '{{.VIRTUAL_ENV}}/bin/python3 -m pip install --upgrade --requirement "{{.PIP_REQUIREMENTS_FILE}}"'
+    sources:
+      - '{{.PIP_REQUIREMENTS_FILE}}'
+    generates:
+      - '{{.VIRTUAL_ENV}}/pyvenv.cfg'
+    preconditions:
+      - msg: Missing Pip requirements file
+        sh: test -f {{.PIP_REQUIREMENTS_FILE}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -47,11 +47,11 @@ tasks:
     prompt: Any conflicting config in the kubernetes directory will be overwritten... continue?
     deps: ['workstation:direnv', 'workstation:venv', 'sops:age-keygen', 'init']
     cmds:
-      - task: .template
+      - task: template
       - task: sops:encrypt
-      - task: .validate
+      - task: validate
 
-  .template:
+  template:
     internal: true
     cmd: '{{.VIRTUAL_ENV}}/bin/makejinja'
     preconditions:
@@ -64,7 +64,7 @@ tasks:
       - msg: Missing bootstrap config file
         sh: test -f {{.BOOTSTRAP_CONFIG_FILE}}
 
-  .validate:
+  validate:
     internal: true
     cmds:
       - task: kubernetes:kubeconform

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,18 +3,13 @@
 version: '3'
 
 vars:
-  # Directories
   BOOTSTRAP_DIR: '{{.ROOT_DIR}}/bootstrap'
   KUBERNETES_DIR: '{{.ROOT_DIR}}/kubernetes'
   PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
   SCRIPTS_DIR: '{{.ROOT_DIR}}/scripts'
-  # Files
   BOOTSTRAP_CONFIG_FILE: '{{.ROOT_DIR}}/config.yaml'
   MAKEJINJA_CONFIG_FILE: '{{.ROOT_DIR}}/makejinja.toml'
-  PIP_REQUIREMENTS_FILE: '{{.ROOT_DIR}}/requirements.txt'
   SOPS_CONFIG_FILE: '{{.ROOT_DIR}}/.sops.yaml'
-  # Binaries
-  PYTHON_BIN: python3
 
 env:
   KUBECONFIG: '{{.ROOT_DIR}}/kubeconfig'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,28 +1,26 @@
 ---
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
-version: "3"
+version: '3'
 
 vars:
   # Directories
-  BOOTSTRAP_DIR: "{{.ROOT_DIR}}/bootstrap"
-  KUBERNETES_DIR: "{{.ROOT_DIR}}/kubernetes"
-  PRIVATE_DIR: "{{.ROOT_DIR}}/.private"
-  SCRIPTS_DIR: "{{.ROOT_DIR}}/scripts"
+  BOOTSTRAP_DIR: '{{.ROOT_DIR}}/bootstrap'
+  KUBERNETES_DIR: '{{.ROOT_DIR}}/kubernetes'
+  PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
+  SCRIPTS_DIR: '{{.ROOT_DIR}}/scripts'
   # Files
-  AGE_FILE: "{{.ROOT_DIR}}/age.key"
-  BOOTSTRAP_CONFIG_FILE: "{{.ROOT_DIR}}/config.yaml"
-  KUBECONFIG_FILE: "{{.ROOT_DIR}}/kubeconfig"
-  MAKEJINJA_CONFIG_FILE: "{{.ROOT_DIR}}/makejinja.toml"
-  PIP_REQUIREMENTS_FILE: "{{.ROOT_DIR}}/requirements.txt"
-  SOPS_CONFIG_FILE: "{{.ROOT_DIR}}/.sops.yaml"
+  BOOTSTRAP_CONFIG_FILE: '{{.ROOT_DIR}}/config.yaml'
+  MAKEJINJA_CONFIG_FILE: '{{.ROOT_DIR}}/makejinja.toml'
+  PIP_REQUIREMENTS_FILE: '{{.ROOT_DIR}}/requirements.txt'
+  SOPS_CONFIG_FILE: '{{.ROOT_DIR}}/.sops.yaml'
   # Binaries
   PYTHON_BIN: python3
 
 env:
-  KUBECONFIG: "{{.KUBECONFIG_FILE}}"
-  PYTHONDONTWRITEBYTECODE: "1"
-  SOPS_AGE_KEY_FILE: "{{.AGE_FILE}}"
-  VIRTUAL_ENV: "{{.ROOT_DIR}}/.venv"
+  KUBECONFIG: '{{.ROOT_DIR}}/kubeconfig'
+  PYTHONDONTWRITEBYTECODE: '1'
+  SOPS_AGE_KEY_FILE: '{{.ROOT_DIR}}/age.key'
+  VIRTUAL_ENV: '{{.ROOT_DIR}}/.venv'
 
 includes:
   kubernetes: .taskfiles/Kubernetes
@@ -53,7 +51,7 @@ tasks:
   configure:
     desc: Configure repository from bootstrap vars
     prompt: Any conflicting config in the kubernetes directory will be overwritten... continue?
-    deps: ["workstation:direnv", "workstation:venv", "sops:age-keygen", "init"]
+    deps: ['workstation:direnv', 'workstation:venv', 'sops:age-keygen', 'init']
     cmds:
       - task: .template
       - task: sops:encrypt
@@ -61,7 +59,7 @@ tasks:
 
   .template:
     internal: true
-    cmd: "{{.VIRTUAL_ENV}}/bin/makejinja"
+    cmd: '{{.VIRTUAL_ENV}}/bin/makejinja'
     preconditions:
       - msg: Missing virtual environment
         sh: test -d {{.VIRTUAL_ENV}}
@@ -77,14 +75,6 @@ tasks:
     cmds:
       - task: kubernetes:kubeconform
       - cmd: echo === Done rendering and validating YAML ===
-      - cmd: |
-          if [[ $KUBECONFIG != "{{.KUBECONFIG_FILE}}" ]]; then
-            echo WARNING: KUBECONFIG is not set to the expected value, this may cause conflicts.
-          fi
-      - cmd: |
-          if [[ $SOPS_AGE_KEY_FILE != "{{.AGE_FILE}}" ]]; then
-            echo WARNING: SOPS_AGE_KEY_FILE is not set to the expected value, this may cause conflicts.
-          fi
       - cmd: |
           if test -f ~/.config/sops/age/keys.txt; then
             echo WARNING: SOPS Age key found in home directory, this may cause conflicts.

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,7 +5,6 @@ version: '3'
 vars:
   BOOTSTRAP_DIR: '{{.ROOT_DIR}}/bootstrap'
   KUBERNETES_DIR: '{{.ROOT_DIR}}/kubernetes'
-  PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
   SCRIPTS_DIR: '{{.ROOT_DIR}}/scripts'
   BOOTSTRAP_CONFIG_FILE: '{{.ROOT_DIR}}/config.yaml'
   MAKEJINJA_CONFIG_FILE: '{{.ROOT_DIR}}/makejinja.toml'


### PR DESCRIPTION
All below changes will required at least go-task version 3.39.2

- Update taskfiles to use styling guide (UPPER vars)
- Enable taskfile to override system environment vars via direnv (simplifies `KUBECONFIG` and `SOPS_AGE_KEY_FILE` vars)
- Nits with quotes and lists in taskfiles
- Move certain vars in taskfiles to their respective taskfile
