### PR TITLE
fix(taskfile): remove redundant braces

### DIFF
--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -25,7 +25,7 @@ tasks:
   apply-node:
     desc: Apply Talos config to a node [HOSTNAME=required]
     cmds:
-      - talosctl --nodes {{.HOSTNAME}} apply-config --mode={{.MODE}}}} --file {{.TALHELPER_CLUSTER_DIR}}/{{.CLUSTER_NAME}}-{{.HOSTNAME}}.yaml
+      - talosctl --nodes {{.HOSTNAME}} apply-config --mode={{.MODE}} --file {{.TALHELPER_CLUSTER_DIR}}/{{.CLUSTER_NAME}}-{{.HOSTNAME}}.yaml
       - talosctl --nodes {{.HOSTNAME}} health --wait-timeout=10m --server=false
     vars:
       CLUSTER_NAME:


### PR DESCRIPTION
During updating the config of my cluster I discovered the task had some redundant braces.

Example: 
```sh
task talos:apply-node HOSTNAME=control-1 MODE=auto
task: [talos:apply-node] talosctl --nodes control-1 apply-config --mode=auto}} --file /home/runner/cluster/kubernetes/bootstrap/talos/clusterconfig/cluster-control-1.yaml
invalid argument "auto}}" for "-m, --mode" flag: possible options are: auto, interactive, no-reboot, reboot, staged, try
```

This PR fixes that.