### PR TITLE
fix: update talos service discovery

### DIFF
--- a/bootstrap/templates/kubernetes/bootstrap/talos/patches/controller/cluster.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/patches/controller/cluster.yaml.j2
@@ -1,5 +1,8 @@
 cluster:
   allowSchedulingOnControlPlanes: true
+  apiServer:
+    extraArgs:
+      feature-gates: AuthorizeNodeWithSelectors=false
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0

--- a/bootstrap/templates/kubernetes/bootstrap/talos/patches/global/cluster-discovery.yaml.j2
+++ b/bootstrap/templates/kubernetes/bootstrap/talos/patches/global/cluster-discovery.yaml.j2
@@ -1,0 +1,7 @@
+cluster:
+  discovery:
+    registries:
+      kubernetes:
+        disabled: false
+      service:
+        disabled: true


### PR DESCRIPTION
Prevents log spam and maybe other issues

```
master-0.ishioni.casa: user: warning: [2024-12-18T22:55:14.499355998Z]: [talos] kubernetes registry node watch error {"component": "controller-runtime", "controller": "cluster.KubernetesPullController", "error": "failed to list *v1.Node: nodes is forbidden: User \"system:node:master-0\" cannot list resource \"nodes\" in API group \"\" at the cluster scope: node 'master-0' cannot read all nodes, only its own Node object"}
```