### PR TITLE
fix(task-kubernetes:apply-ks): --dry-run was appended to the path, ma…

### DIFF
--- a/.taskfiles/kubernetes/Taskfile.yaml
+++ b/.taskfiles/kubernetes/Taskfile.yaml
@@ -12,7 +12,7 @@ tasks:
     cmd: >
       flux build --namespace flux-system ks {{base .PATH}}
       --kustomization-file {{.KUBERNETES_DIR}}/apps/{{.PATH}}/ks.yaml
-      --path {{.KUBERNETES_DIR}}/apps/{{.PATH}}{{- if contains "not found" .KS }}--dry-run \{{ end }}
+      --path {{.KUBERNETES_DIR}}/apps/{{.PATH}}{{- if contains "not found" .KS }} --dry-run \{{ end }}
       | yq 'with(select(.apiVersion == "kustomize.toolkit.fluxcd.io/v1" and .kind == "Kustomization"); .metadata.namespace = "flux-system")' -
       | kubectl apply --server-side --field-manager=kustomize-controller --filename -
     requires:


### PR DESCRIPTION
Hello @onedr0p,
the task `kubernetes:apply-ks`  was causing the `PATH` to be invalid it appended the `--dry-run` to the path.