### PR TITLE
fix(template): remove options for extra manifests and extension config

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -95,7 +95,7 @@ secureboot:
   # (OPTIONAL) Enable secureboot on UEFI systems. Not supported on x86 platforms in BIOS mode.
   enabled: false
   # (OPTIONAL) Enable TPM-based disk encryption. Requires TPM 2.0
-  encrypt_disk_with_tpm: false
+  encrypt_disk: false
 
 # (OPTIONAL) Change Cilium load balancer mode
 #   Ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -23,16 +23,6 @@ node_inventory: []
   #   mac_addr: ""        # (REQUIRED) MAC address of the NIC for this node, must be lowercase (talosctl get links -n <ip> --insecure)
   #   schematic_id: ""    # (OPTIONAL) Override the 'schematic_id' with a node specific schematic ID from https://factory.talos.dev/
   #   mtu: ""             # (OPTIONAL) MTU for the NIC. DEFAULT: 1500
-  #   manifests:          # (OPTIONAL) Additional manifests to include after MachineConfig
-  #     - extra.yaml      #            Ref: https://www.talos.dev/v1.7/reference/configuration/extensions/extensionserviceconfig/
-  #   extension_services: # (OPTIONAL) Additional talhelper ExtensionServices (supports talenv.sops.yaml envsubst)
-  #     - name: name
-  #       configFiles:
-  #         - content: |-
-  #             ...
-  #       mountPath: ...
-  #       environment:
-  #         - key=value
   # ...
 
 # (REQUIRED) The DNS servers to use for the cluster nodes.

--- a/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -90,7 +90,7 @@ nodes:
 
 # Global patches
 patches:
-  #% if secureboot.enabled and secureboot.encrypt %#
+  #% if secureboot.enabled and secureboot.encrypt_disk %#
   - # Encrypt system disk with TPM
     |-
     machine:

--- a/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -90,7 +90,7 @@ nodes:
 
 # Global patches
 patches:
-  #% if secureboot.enabled and secureboot.encrypt_disk_with_tpm %#
+  #% if secureboot.enabled and secureboot.encrypt %#
   - # Encrypt system disk with TPM
     |-
     machine:

--- a/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -80,30 +80,6 @@ nodes:
           ip: "#{ controller_vip }#"
         #% endif %#
         #% endif %#
-    #% if item.manifests %#
-    extraManifests:
-      #% for manifest in item.manifests %#
-      - #{ manifest }#
-      #% endfor %#
-    #% endif %#
-    #% if item.extension_services %#
-    extensionServices:
-      #% for es in item.extension_services %#
-      - name: #{ es.name }#
-        configFiles:
-        #% for cf in es.configFiles %#
-          - content: |-
-              #{ cf.content | indent(14, yes) }#
-            mountPath: #{ cf.mountPath }#
-        #% endfor %#
-        #% if es.environment %#
-        environment:
-          #% for env in es.environment %#
-          - #{ env }#
-          #% endfor %#
-        #% endif %#
-      #% endfor %#
-    #% endif %#
     #% for file in talos_patches('%s' % (item.name)) %#
     #% if loop.index == 1 %#
     patches:


### PR DESCRIPTION
These aren't needed to get a working cluster ready and can be done with a talos upgrade later on. These options will just confuse people getting started.