### PR TITLE
correct github private key reference in cluster.yaml.j2

### DIFF
--- a/templates/config/kubernetes/flux/config/cluster.yaml.j2
+++ b/templates/config/kubernetes/flux/config/cluster.yaml.j2
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 30m
   url: "#{ github.address }#"
-  #% if github_private_key %#
+  #% if github.private_key %#
   secretRef:
     name: github-deploy-key
   #% endif %#


### PR DESCRIPTION
flux failing due to not finding github.private_key when using config sample.