### PR TITLE
fix ssl cert for ingresses

### DIFF
--- a/templates/config/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/ingress-nginx/external/helmrelease.yaml.j2
@@ -76,7 +76,7 @@ spec:
           namespaceSelector:
             any: true
       extraArgs:
-        default-ssl-certificate: "${SECRET_DOMAIN/./-}-#{ 'production' if cloudflare.acme.production else 'staging' }#-tls"
+        default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-#{ 'production' if cloudflare.acme.production else 'staging' }#-tls"
       resources:
         requests:
           cpu: 100m

--- a/templates/config/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/ingress-nginx/internal/helmrelease.yaml.j2
@@ -71,7 +71,7 @@ spec:
           namespaceSelector:
             any: true
       extraArgs:
-        default-ssl-certificate: "${SECRET_DOMAIN/./-}-#{ 'production' if cloudflare.acme.production else 'staging' }#-tls"
+        default-ssl-certificate: "network/${SECRET_DOMAIN/./-}-#{ 'production' if cloudflare.acme.production else 'staging' }#-tls"
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
adding back the network namespace that was (unintentionally?) removed in https://github.com/onedr0p/cluster-template/commit/3659673e2d3cb1bfd0f9e30b9cabedbde014a0ba