### PR TITLE
Node secureboot and disk encrypt

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -17,6 +17,9 @@ node_inventory: []
   #   mac_addr: ""        # (REQUIRED) MAC address of the NIC for this node, must be lowercase (talosctl get links -n <ip> --insecure)
   #   schematic_id: ""    # (REQUIRED) Schematic ID from https://factory.talos.dev/
   #   mtu: ""             # (OPTIONAL) MTU for the NIC. DEFAULT: 1500
+  ## For secureboot/encrypt_disk, please refer to https://www.talos.dev/latest/talos-guides/install/bare-metal-platforms/secureboot
+  #   secureboot: false   # (OPTIONAL) Enable secureboot on UEFI systems. Not supported on x86 platforms in BIOS mode.
+  #   encrypt_disk: false # (OPTIONAL) Enable TPM-based disk encryption. Requires TPM 2.0
   # ...
 
 # (REQUIRED) The DNS servers to use for the cluster nodes. (DEFAULT: Cloudflare DNS)
@@ -169,14 +172,6 @@ bgp:
   router_asn: 64513
   # (REQUIRED) Node ASN
   node_asn: 64514
-
-# (OPTIONAL) Secureboot and TPM-based disk encryption
-#   Ref: https://www.talos.dev/v1.9/talos-guides/install/bare-metal-platforms/secureboot
-secureboot:
-  # (OPTIONAL) Enable secureboot on UEFI systems. Not supported on x86 platforms in BIOS mode.
-  enabled: false
-  # (OPTIONAL) Enable TPM-based disk encryption. Requires TPM 2.0
-  encrypt_disk: false
 
 # (OPTIONAL) Enable Dual Stack IPv4 first
 #   IMPORTANT: I am looking for people to help contribute IPv6 support since I cannot test it.

--- a/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/talos/talconfig.yaml.j2
@@ -36,8 +36,8 @@ nodes:
       serial: "#{ item.disk }#"
     #% endif %#
     machineSpec:
-      secureboot: #{ true if secureboot.enabled else false | lower }#
-    talosImageURL: factory.talos.dev/installer#{ "-secureboot" if secureboot.enabled else ""}#/#{ item.schematic_id }#
+      secureboot: #{ true if item.secureboot else false | lower }#
+    talosImageURL: factory.talos.dev/installer#{ "-secureboot" if item.secureboot else ""}#/#{ item.schematic_id }#
     controlPlane: #{ (item.controller) | string | lower }#
     networkInterfaces:
       - deviceSelector:
@@ -76,32 +76,52 @@ nodes:
           ip: "#{ controller_vip }#"
         #% endif %#
         #% endif %#
-    #% for file in talos_patches('%s' % (item.name)) %#
-    #% if loop.index == 1 %#
+    #% if talos_patches('%s' % (item.name)) | length == 0 %#
+      #% if item.encrypt_disk %#
     patches:
-    #% endif %#
+      - # Encrypt system disk with TPM
+        |-
+        machine:
+          systemDiskEncryption:
+            state:
+              provider: luks2
+              keys:
+                - slot: 0
+                  tpm: {}
+            ephemeral:
+              provider: luks2
+              keys:
+                - slot: 0
+                  tpm: {}
+      #% endif %#
+    #% else %#
+      #% for file in talos_patches('%s' % (item.name)) %#
+        #% if loop.index == 1 %#
+    patches:
+          #% if item.encrypt_disk %#
+      - # Encrypt system disk with TPM
+        |-
+        machine:
+          systemDiskEncryption:
+            state:
+              provider: luks2
+              keys:
+                - slot: 0
+                  tpm: {}
+            ephemeral:
+              provider: luks2
+              keys:
+                - slot: 0
+                  tpm: {}
+          #% endif %#
+        #% endif %#
       - "@./patches/#{ item.name }#/#{ file | basename }#"
-    #% endfor %#
+      #% endfor %#
+    #% endif %#
   #% endfor %#
 
 # Global patches
 patches:
-  #% if secureboot.enabled and secureboot.encrypt_disk %#
-  - # Encrypt system disk with TPM
-    |-
-    machine:
-      systemDiskEncryption:
-        ephemeral:
-          provider: luks2
-          keys:
-            - slot: 0
-              tpm: {}
-        state:
-          provider: luks2
-          keys:
-            - slot: 0
-              tpm: {}
-  #% endif %#
   #% for file in talos_patches('global') %#
   - "@./patches/global/#{ file | basename }#"
   #% endfor %#


### PR DESCRIPTION
Moving the global secureboot/encrypt_disk option to be node specific. Useful for multi-arch clusters where some nodes don't support one of those options, like older NUCs or Raspberry Pi's SBCs.