### PR TITLE
chore: remove config sample yaml as part of task template:tidy

### DIFF
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -92,6 +92,7 @@ tasks:
       - mv {{.TEMPLATE_DIR}} {{.TIDY_FOLDER}}/templates
       - mv {{.MAKEJINJA_CONFIG_FILE}} {{.TIDY_FOLDER}}/makejinja.toml
       - mv {{.ROOT_DIR}}/requirements.txt {{.TIDY_FOLDER}}/requirements.txt
+      - mv {{.TEMPLATE_CONFIG_FILE}} {{.TIDY_FOLDER}}/config.sample.yaml
       - mv {{.TEMPLATE_CONFIG_FILE}} {{.TIDY_FOLDER}}/config.yaml
       - |
         {{.SED}} '/template:/d' {{.ROOT_DIR}}/Taskfile.yaml


### PR DESCRIPTION
task template:tidy 
is cleaning up all the files except config.sample.yaml