### PR TITLE
Replace outdated links in config template, added text to post-bootstr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ There are **4 stages** outlined below for completing this project, make sure you
 
 1. Install Talos:
 
-   📍 _It might take a while for the cluster to be setup (10+ minutes is normal). During which time you will see a variety of error messages like: "couldn't get current server API group list," "error: no matching resources found", etc. **This is a normal.** If this step gets interrupted, e.g. by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd>, you likely will need to [reset the cluster](#-reset) before trying again_
+   📍 _It might take a while for the cluster to be setup (10+ minutes is normal). During which time you will see a variety of error messages like: "couldn't get current server API group list," "error: no matching resources found", etc. 'Ready' will remain "False" as no CNI is deployed yet. **This is a normal.** If this step gets interrupted, e.g. by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd>, you likely will need to [reset the cluster](#-reset) before trying again_
 
     ```sh
     task bootstrap:talos

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -12,7 +12,7 @@ node_inventory: []
   # - name: ""            # (REQUIRED) Name of the node (must match [a-z0-9-\]+)
   #   address: ""         # (REQUIRED) IP address of the node
   #   controller: true    # (REQUIRED) Set to true if this is a controller node
-  #   disk: ""            # (REQUIRED) Device path or serial number of the disk for this node (talosctl disks -n <ip> --insecure)
+  #   disk: ""            # (REQUIRED) Device path or serial number of the disk for this node (talosctl get disks -n <ip> --insecure)
   #   mac_addr: ""        # (REQUIRED) MAC address of the NIC for this node, must be lowercase (talosctl get links -n <ip> --insecure)
   #   schematic_id: ""    # (REQUIRED) Schematic ID from https://factory.talos.dev/
   #   mtu: 1500           # (ADVANCED/OPTIONAL) MTU for the NIC. DEFAULT: 1500
@@ -161,7 +161,7 @@ loadbalancer_mode: "dsr"
 # (OPTIONAL) Use cilium BGP control plane for L3 routing
 #   Needs a BGP capable router setup with the node IPs as peers.
 #   To keep things simple, node network will be used for BGP peering.
-#   Ref: https://docs.cilium.io/en/latest/network/bgp-control-plane/
+#   Ref: https://docs.cilium.io/en/latest/network/bgp-control-plane/bgp-control-plane/
 bgp:
   enabled: false
   # (REQUIRED) Router IP address - BGP must be configured on this router using FRR or similar


### PR DESCRIPTION
Just rebuilt cluster again - noticed a couple of outdated links and perhaps adding a bit more clarity to expected talos state post bootstrap:

- Updated outdated links in config.sample.yaml
- Added text around ready state being false until apps are installed