### PR TITLE
Execute talhelper validate within the talos directory

### DIFF
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -75,9 +75,12 @@ tasks:
   validate-talos-config:
     desc: Validate the Talhelper config
     cmd: talhelper validate talconfig {{.TALHELPER_CONFIG_FILE}}
+    dir: '{{.TALHELPER_CONFIG_DIR}}'
     preconditions:
       - test -f {{.TALHELPER_CONFIG_FILE}}
       - which talhelper
+    vars:
+      TALHELPER_CONFIG_DIR: '{{.TALHELPER_CONFIG_FILE | dir}}'
 
   tidy:
     desc: Archive template related files and directories


### PR DESCRIPTION
`talhelper validate talconfig` doesn't automatically pickup encrypted variables in the `talenv.sops.yaml` when executed outside of the talos directory. This can be overridden by specifying `--env-file path/to/talenv.sops.yaml` but not everyone will be using this file so we should not add it to the template:validate-talos-config cmd value. Instead we can utilize the `dir` key from https://taskfile.dev/usage/#task-directory to automatically have the working directory of the command use the directory containing the talenv.sops.yaml file. This allows the task to succeed in both situations, when using encrypted variables and without.

Without patch:
```
talconfig.yaml:
...
    extensionServices:
      - name: nut-client
        configFiles:
          - content: |-
              MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
...

talenv.sops.yaml:
upsmonUpsName: <hidden>
...

$ task configure
...
task: [template:validate-talos-config] talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml                                                2025/01/26 04:02:03 failed trying to substitute env: variable ${upsmonUpsName} not set
```

Manually works with:
```
$ talhelper validate talconfig --env-file /cluster-template/kubernetes/bootstrap/talos/talenv.sops.yaml /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml
```

And with:
```
$ pushd /cluster-template/kubernetes/bootstrap/talos ; talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml ; popd
/cluster-template/kubernetes/bootstrap/talos /cluster-template
Your talhelper config file is looking great!
/cluster-template
```

With patch:
```
task: [template:validate-talos-config] talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml
Your talhelper config file is looking great!
```