### PR TITLE
Execute talhelper commands within the talos directory

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -13,10 +13,10 @@ tasks:
     cmds:
       - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}talhelper gensecret > {{.TALHELPER_SECRET_FILE}}{{end}}'
       - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}sops --encrypt --in-place {{.TALHELPER_SECRET_FILE}}{{end}}'
-      - talhelper genconfig --config-file {{.TALHELPER_CONFIG_FILE}} --secret-file {{.TALHELPER_SECRET_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}}
-      - talhelper gencommand apply --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="--insecure" | bash
-      - until talhelper gencommand bootstrap --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} | bash; do sleep 10; done
-      - until talhelper gencommand kubeconfig --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
+      - talhelper genconfig
+      - talhelper gencommand apply --extra-flags="--insecure" | bash
+      - until talhelper gencommand bootstrap | bash; do sleep 10; done
+      - until talhelper gencommand kubeconfig --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
     vars:
       TALHELPER_SECRET_EXISTS:
         sh: test -f {{.TALHELPER_SECRET_FILE}} && echo true || echo false

--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -11,19 +11,19 @@ tasks:
     desc: Bootstrap the Talos cluster
     dir: '{{.KUBERNETES_DIR}}/bootstrap/talos'
     cmds:
-      - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}talhelper gensecret > {{.TALHELPER_SECRET_FILE}}{{end}}'
-      - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}sops --encrypt --in-place {{.TALHELPER_SECRET_FILE}}{{end}}'
+      - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}talhelper gensecret > {{.TALHELPER_DIR}}/talsecret.sops.yaml{{end}}'
+      - '{{if eq .TALHELPER_SECRET_EXISTS "false"}}sops --encrypt --in-place {{.TALHELPER_DIR}}/talsecret.sops.yaml{{end}}'
       - talhelper genconfig
       - talhelper gencommand apply --extra-flags="--insecure" | bash
       - until talhelper gencommand bootstrap | bash; do sleep 10; done
       - until talhelper gencommand kubeconfig --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
     vars:
       TALHELPER_SECRET_EXISTS:
-        sh: test -f {{.TALHELPER_SECRET_FILE}} && echo true || echo false
+        sh: test -f {{.TALHELPER_DIR}}/talsecret.sops.yaml && echo true || echo false
     preconditions:
       - test -f {{.SOPS_CONFIG_FILE}}
       - test -f {{.SOPS_AGE_KEY_FILE}}
-      - test -f {{.TALHELPER_CONFIG_FILE}}
+      - test -f {{.TALHELPER_DIR}}/talconfig.yaml
       - which talhelper sops
 
   apps:

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -2,11 +2,14 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: '3'
 
+vars:
+  TALHELPER_CONFIG_DIR: "{{.TALHELPER_CONFIG_FILE | dir}}"
+
 tasks:
 
   generate-config:
     desc: Generate Talos configuration
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: "{{.TALHELPER_CONFIG_DIR}}"
     cmd: talhelper genconfig --config-file {{.TALHELPER_CONFIG_FILE}} --secret-file {{.TALHELPER_SECRET_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}}
     preconditions:
       - test -f {{.TALHELPER_CONFIG_FILE}}
@@ -16,7 +19,7 @@ tasks:
 
   apply-node:
     desc: Apply Talos config to a node [IP=required]
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: "{{.TALHELPER_CONFIG_DIR}}"
     cmd: talhelper gencommand apply --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags '--mode={{.MODE}}' | bash
     vars:
       MODE: '{{.MODE | default "auto"}}'
@@ -30,7 +33,7 @@ tasks:
 
   upgrade-node:
     desc: Upgrade Talos on a single node [IP=required]
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: "{{.TALHELPER_CONFIG_DIR}}"
     cmd: talhelper gencommand upgrade --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--image='factory.talos.dev/installer{{if eq .TALOS_SECUREBOOT "true"}}-secureboot{{end}}/{{.TALOS_SCHEMATIC_ID}}:{{.TALOS_VERSION}}' --timeout=10m" | bash
     vars:
       TALOS_SCHEMATIC_ID:
@@ -49,7 +52,7 @@ tasks:
 
   upgrade-k8s:
     desc: Upgrade Kubernetes
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: "{{.TALHELPER_CONFIG_DIR}}"
     cmd: talhelper gencommand upgrade-k8s --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--to '{{.KUBERNETES_VERSION}}'" | bash
     vars:
       KUBERNETES_VERSION:
@@ -61,7 +64,7 @@ tasks:
 
   reset:
     desc: Resets nodes back to maintenance mode
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
+    dir: "{{.TALHELPER_CONFIG_DIR}}"
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     cmd: talhelper gencommand reset --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
     preconditions:

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -2,24 +2,21 @@
 # yaml-language-server: $schema=https://taskfile.dev/schema.json
 version: '3'
 
-vars:
-  TALHELPER_CONFIG_DIR: "{{.TALHELPER_CONFIG_FILE | dir}}"
-
 tasks:
 
   generate-config:
     desc: Generate Talos configuration
-    dir: "{{.TALHELPER_CONFIG_DIR}}"
+    dir: "{{.TALHELPER_DIR}}"
     cmd: talhelper genconfig
     preconditions:
-      - test -f {{.TALHELPER_CONFIG_FILE}}
+      - test -f {{.TALHELPER_DIR}}/talconfig.yaml
       - test -f {{.SOPS_CONFIG_FILE}}
       - test -f {{.SOPS_AGE_KEY_FILE}}
       - which talhelper
 
   apply-node:
     desc: Apply Talos config to a node [IP=required]
-    dir: "{{.TALHELPER_CONFIG_DIR}}"
+    dir: "{{.TALHELPER_DIR}}"
     cmd: talhelper gencommand apply --node {{.IP}} --extra-flags '--mode={{.MODE}}' | bash
     vars:
       MODE: '{{.MODE | default "auto"}}'
@@ -33,15 +30,15 @@ tasks:
 
   upgrade-node:
     desc: Upgrade Talos on a single node [IP=required]
-    dir: "{{.TALHELPER_CONFIG_DIR}}"
+    dir: "{{.TALHELPER_DIR}}"
     cmd: talhelper gencommand upgrade --node {{.IP}} --extra-flags "--image='factory.talos.dev/installer{{if eq .TALOS_SECUREBOOT "true"}}-secureboot{{end}}/{{.TALOS_SCHEMATIC_ID}}:{{.TALOS_VERSION}}' --timeout=10m" | bash
     vars:
       TALOS_SCHEMATIC_ID:
-        sh: yq '.nodes[] | select(.ipAddress == "{{.IP}}") | .talosImageURL' {{.TALHELPER_CONFIG_FILE}} | awk -F/ '{print $NF}'
+        sh: yq '.nodes[] | select(.ipAddress == "{{.IP}}") | .talosImageURL' {{.TALHELPER_DIR}}/talconfig.yaml | awk -F/ '{print $NF}'
       TALOS_SECUREBOOT:
-        sh: yq '.nodes[] | select(.ipAddress == "{{.IP}}") | .machineSpec.secureboot' {{.TALHELPER_CONFIG_FILE}}
+        sh: yq '.nodes[] | select(.ipAddress == "{{.IP}}") | .machineSpec.secureboot' {{.TALHELPER_DIR}}/talconfig.yaml
       TALOS_VERSION:
-        sh: yq '.talosVersion' {{.TALHELPER_CONFIG_FILE}}
+        sh: yq '.talosVersion' {{.TALHELPER_DIR}}/talconfig.yaml
     requires:
       vars: [IP]
     preconditions:
@@ -52,11 +49,11 @@ tasks:
 
   upgrade-k8s:
     desc: Upgrade Kubernetes
-    dir: "{{.TALHELPER_CONFIG_DIR}}"
+    dir: "{{.TALHELPER_DIR}}"
     cmd: talhelper gencommand upgrade-k8s --extra-flags "--to '{{.KUBERNETES_VERSION}}'" | bash
     vars:
       KUBERNETES_VERSION:
-        sh: yq '.kubernetesVersion' {{.TALHELPER_CONFIG_FILE}}
+        sh: yq '.kubernetesVersion' {{.TALHELPER_DIR}}/talconfig.yaml
     preconditions:
       - talosctl config info
       - test -f {{.TALOSCONFIG}}
@@ -64,7 +61,7 @@ tasks:
 
   reset:
     desc: Resets nodes back to maintenance mode
-    dir: "{{.TALHELPER_CONFIG_DIR}}"
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
     cmd: talhelper gencommand reset --extra-flags="--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
     preconditions:

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -6,6 +6,7 @@ tasks:
 
   generate-config:
     desc: Generate Talos configuration
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     cmd: talhelper genconfig --config-file {{.TALHELPER_CONFIG_FILE}} --secret-file {{.TALHELPER_SECRET_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}}
     preconditions:
       - test -f {{.TALHELPER_CONFIG_FILE}}
@@ -15,6 +16,7 @@ tasks:
 
   apply-node:
     desc: Apply Talos config to a node [IP=required]
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     cmd: talhelper gencommand apply --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags '--mode={{.MODE}}' | bash
     vars:
       MODE: '{{.MODE | default "auto"}}'
@@ -28,6 +30,7 @@ tasks:
 
   upgrade-node:
     desc: Upgrade Talos on a single node [IP=required]
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     cmd: talhelper gencommand upgrade --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--image='factory.talos.dev/installer{{if eq .TALOS_SECUREBOOT "true"}}-secureboot{{end}}/{{.TALOS_SCHEMATIC_ID}}:{{.TALOS_VERSION}}' --timeout=10m" | bash
     vars:
       TALOS_SCHEMATIC_ID:
@@ -46,6 +49,7 @@ tasks:
 
   upgrade-k8s:
     desc: Upgrade Kubernetes
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     cmd: talhelper gencommand upgrade-k8s --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--to '{{.KUBERNETES_VERSION}}'" | bash
     vars:
       KUBERNETES_VERSION:

--- a/.taskfiles/talos/Taskfile.yaml
+++ b/.taskfiles/talos/Taskfile.yaml
@@ -10,7 +10,7 @@ tasks:
   generate-config:
     desc: Generate Talos configuration
     dir: "{{.TALHELPER_CONFIG_DIR}}"
-    cmd: talhelper genconfig --config-file {{.TALHELPER_CONFIG_FILE}} --secret-file {{.TALHELPER_SECRET_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}}
+    cmd: talhelper genconfig
     preconditions:
       - test -f {{.TALHELPER_CONFIG_FILE}}
       - test -f {{.SOPS_CONFIG_FILE}}
@@ -20,7 +20,7 @@ tasks:
   apply-node:
     desc: Apply Talos config to a node [IP=required]
     dir: "{{.TALHELPER_CONFIG_DIR}}"
-    cmd: talhelper gencommand apply --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags '--mode={{.MODE}}' | bash
+    cmd: talhelper gencommand apply --node {{.IP}} --extra-flags '--mode={{.MODE}}' | bash
     vars:
       MODE: '{{.MODE | default "auto"}}'
     requires:
@@ -34,7 +34,7 @@ tasks:
   upgrade-node:
     desc: Upgrade Talos on a single node [IP=required]
     dir: "{{.TALHELPER_CONFIG_DIR}}"
-    cmd: talhelper gencommand upgrade --node {{.IP}} --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--image='factory.talos.dev/installer{{if eq .TALOS_SECUREBOOT "true"}}-secureboot{{end}}/{{.TALOS_SCHEMATIC_ID}}:{{.TALOS_VERSION}}' --timeout=10m" | bash
+    cmd: talhelper gencommand upgrade --node {{.IP}} --extra-flags "--image='factory.talos.dev/installer{{if eq .TALOS_SECUREBOOT "true"}}-secureboot{{end}}/{{.TALOS_SCHEMATIC_ID}}:{{.TALOS_VERSION}}' --timeout=10m" | bash
     vars:
       TALOS_SCHEMATIC_ID:
         sh: yq '.nodes[] | select(.ipAddress == "{{.IP}}") | .talosImageURL' {{.TALHELPER_CONFIG_FILE}} | awk -F/ '{print $NF}'
@@ -53,7 +53,7 @@ tasks:
   upgrade-k8s:
     desc: Upgrade Kubernetes
     dir: "{{.TALHELPER_CONFIG_DIR}}"
-    cmd: talhelper gencommand upgrade-k8s --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags "--to '{{.KUBERNETES_VERSION}}'" | bash
+    cmd: talhelper gencommand upgrade-k8s --extra-flags "--to '{{.KUBERNETES_VERSION}}'" | bash
     vars:
       KUBERNETES_VERSION:
         sh: yq '.kubernetesVersion' {{.TALHELPER_CONFIG_FILE}}
@@ -66,6 +66,6 @@ tasks:
     desc: Resets nodes back to maintenance mode
     dir: "{{.TALHELPER_CONFIG_DIR}}"
     prompt: This will destroy your cluster and reset the nodes back to maintenance mode... continue?
-    cmd: talhelper gencommand reset --config-file {{.TALHELPER_CONFIG_FILE}} --out-dir {{.TALHELPER_CLUSTER_DIR}} --extra-flags="--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
+    cmd: talhelper gencommand reset --extra-flags="--reboot {{- if eq .CLI_FORCE false }} --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL{{ end }} --graceful=false --wait=false" | bash
     preconditions:
       - which talhelper

--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -74,6 +74,7 @@ tasks:
 
   validate-talos-config:
     desc: Validate the Talhelper config
+    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
     cmd: talhelper validate talconfig {{.TALHELPER_CONFIG_FILE}}
     preconditions:
       - test -f {{.TALHELPER_CONFIG_FILE}}

--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -74,10 +74,10 @@ tasks:
 
   validate-talos-config:
     desc: Validate the Talhelper config
-    dir: "{{.KUBERNETES_DIR}}/bootstrap/talos"
-    cmd: talhelper validate talconfig {{.TALHELPER_CONFIG_FILE}}
+    dir: "{{.TALHELPER_DIR}}"
+    cmd: talhelper validate talconfig {{.TALHELPER_DIR}}/talconfig.yaml
     preconditions:
-      - test -f {{.TALHELPER_CONFIG_FILE}}
+      - test -f {{.TALHELPER_DIR}}/talconfig.yaml
       - which talhelper
 
   tidy:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -9,10 +9,8 @@ vars:
   KUBERNETES_DIR: '{{.ROOT_DIR}}/kubernetes'
   PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
   SOPS_CONFIG_FILE: '{{.ROOT_DIR}}/.sops.yaml'
-  TALHELPER_CLUSTER_DIR: '{{.KUBERNETES_DIR}}/bootstrap/talos/clusterconfig'
-  TALHELPER_CONFIG_FILE: '{{.KUBERNETES_DIR}}/bootstrap/talos/talconfig.yaml'
-  TALHELPER_SECRET_FILE: '{{.KUBERNETES_DIR}}/bootstrap/talos/talsecret.sops.yaml'
-  TALOSCONFIG: '{{.TALHELPER_CLUSTER_DIR}}/talosconfig'
+  TALHELPER_DIR: '{{.KUBERNETES_DIR}}/bootstrap/talos'
+  TALOSCONFIG: '{{.TALHELPER_DIR}}/clusterconfig/talosconfig'
 
 env:
   KUBECONFIG: '{{.ROOT_DIR}}/kubeconfig'


### PR DESCRIPTION
`talhelper validate talconfig` doesn't automatically pickup encrypted variables in the `talenv.sops.yaml` when executed outside of the talos directory. This can be overridden by specifying `--env-file path/to/talenv.sops.yaml` but not everyone will be using this file so we should not add it to the template:validate-talos-config cmd value. Instead we can utilize the `dir` key from https://taskfile.dev/usage/#task-directory to automatically have the working directory of the command use the directory containing the talenv.sops.yaml file. This allows the task to succeed in both situations, when using encrypted variables and without.

The `bootstrap:talos` and `talos:reset` tasks already had this set. This PR is to add this to the other tasks using talhelper which similarly have issues when attempting to read the encrypted variables. This ideally replaces #1727 which only handled the `template:validate-talos-config` task with a too-specific branch name.

Without patch:
```
talconfig.yaml:
...
    extensionServices:
      - name: nut-client
        configFiles:
          - content: |-
              MONITOR ${upsmonUpsName}@${upsmonHost}:${upsmonPort} 1 ${upsmonUser} ${upsmonPasswd} slave
...

talenv.sops.yaml:
upsmonUpsName: <hidden>
...

$ task configure
...
task: [template:validate-talos-config] talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml                                                2025/01/26 04:02:03 failed trying to substitute env: variable ${upsmonUpsName} not set
```

Manually works with:
```
$ talhelper validate talconfig --env-file /cluster-template/kubernetes/bootstrap/talos/talenv.sops.yaml /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml
```

And with:
```
$ pushd /cluster-template/kubernetes/bootstrap/talos ; talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml ; popd
/cluster-template/kubernetes/bootstrap/talos /cluster-template
Your talhelper config file is looking great!
/cluster-template
```

With patch:
```
task: [template:validate-talos-config] talhelper validate talconfig /cluster-template/kubernetes/bootstrap/talos/talconfig.yaml
Your talhelper config file is looking great!
```