### PR TITLE
fix: remove email from config and cert manager

### DIFF
--- a/.github/tests/config-talos.yaml
+++ b/.github/tests/config-talos.yaml
@@ -38,7 +38,6 @@ cloudflare:
   domain: fake
   token: take
   acme:
-    email: fake@example.com
     production: false
   tunnel:
     account_id: fake

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -106,8 +106,6 @@ cloudflare:
   token: ""
   # (REQUIRED) Optionals for Cloudflare Acme
   acme:
-    # (REQUIRED) Any email you want to be associated with the ACME account (used for TLS certs via letsencrypt.org)
-    email: ""
     # (REQUIRED) Use the ACME production server when requesting the wildcard certificate.
     #   By default the ACME staging server is used. This is to prevent being rate-limited.
     #   Update this option to `true` when you have verified the staging certificate

--- a/templates/config/kubernetes/apps/cert-manager/cert-manager/issuers/clusterissuers.yaml.j2
+++ b/templates/config/kubernetes/apps/cert-manager/cert-manager/issuers/clusterissuers.yaml.j2
@@ -7,7 +7,6 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: "${SECRET_ACME_EMAIL}"
     privateKeySecretRef:
       name: letsencrypt-production
     solvers:
@@ -28,7 +27,6 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: "${SECRET_ACME_EMAIL}"
     privateKeySecretRef:
       name: letsencrypt-staging
     solvers:

--- a/templates/config/kubernetes/flux/meta/settings/cluster-secrets.sops.yaml.j2
+++ b/templates/config/kubernetes/flux/meta/settings/cluster-secrets.sops.yaml.j2
@@ -8,7 +8,6 @@ metadata:
 #% if cloudflare.enabled %#
 stringData:
   SECRET_DOMAIN: "#{ cloudflare.domain }#"
-  SECRET_ACME_EMAIL: "#{ cloudflare.acme.email }#"
   SECRET_CLOUDFLARE_TUNNEL_ID: "#{ cloudflare.tunnel.id }#"
 #% else %#
 stringData: {}


### PR DESCRIPTION
This field isn't needed anymore since LE will stop sending emails reminding of cert expiry 