### PR TITLE
Add read permission for flux local diff workflow

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: read
     strategy:
       matrix:
         resources: ["helmrelease", "kustomization"]


### PR DESCRIPTION
- This is needed for private repos as setting the permission overwites ALL permissions.
- See https://github.com/actions/checkout/issues/254#issuecomment-981945812 for the explanation for a similar issue.