### PR TITLE
helmfile.yaml.j2 - Switch cilium hook to postsync event

### DIFF
--- a/templates/config/kubernetes/bootstrap/apps/helmfile.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/apps/helmfile.yaml.j2
@@ -26,7 +26,7 @@ releases:
     version: 1.17.0
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/cilium/app/helm-values.yaml']
     hooks:
-      - events: ['presync']
+      - events: ['postsync']
         command: bash
         args: ['{{ requiredEnv "KUBERNETES_DIR" }}/bootstrap/apps/hooks/cilium-config.sh']
 


### PR DESCRIPTION
When running `task bootstrap:apps` the helmfile step gets stuck with no output while executing the cilium release's presync event script "cilium-config.sh". The script is waiting for the Cilium CRDs to become available but is executing before helm installs the release which is when the CRDs will be generated by the operator pod. This needs to be switched to a [postsync](https://helmfile.readthedocs.io/en/latest/#hooks) event to work as expected.

Example problematic run:
```
$ task bootstrap:apps
...
task: [bootstrap:apps] helmfile --file [REDACTED]/kubernetes/bootstrap/apps/helmfile.yaml apply --skip-diff-on-install --suppress-diff
...
Listing releases matching ^flux-operator$
Listing releases matching ^flux-instance$
^Ctask: Signal received: "interrupt"
task: Failed to run task "bootstrap:apps": exit status 130

$ helmfile --file [REDACTED]/kubernetes/bootstrap/apps/helmfile.yaml apply --skip-diff-on-install --suppress-diff --debug
...
processing releases in group 1/5: kube-system/cilium
Successfully generated the value file at [REDACTED]/kubernetes/apps/kube-system/cilium/app/helm-values.yaml. produced:
---
hook[bash]: stateFilePath=helmfile.yaml, basePath=.

hook[bash]: triggered by event "presync"
^Chook[bash]:

Removed /tmp/helmfile3436098181/kube-system-cilium-values-6c5b64855b
Removed /tmp/helmfile3436098181
err: release "cilium" in "helmfile.yaml" failed: failed processing release cilium: hook[bash]: command `bash` failed: command "/home/linuxbrew/.linuxbrew/bin/bash" exited with non-zero status:

PATH:
  /home/linuxbrew/.linuxbrew/bin/bash

ARGS:
  0: bash (4 bytes)
  1: [REDACTED]/kubernetes/bootstrap/apps/hooks/cilium-config.sh (100 bytes)

ERROR:
  signal: interrupt

EXIT STATUS
  -1
changing working directory back to "[REDACTED]"

$ bash -x kubernetes/bootstrap/apps/hooks/cilium-config.sh
+ main
+ wait_for_cilium_crds
+ crds=('ciliuml2announcementpolicies.cilium.io' 'ciliumbgppeeringpolicies.cilium.io' 'ciliumloadbalancerippools.cilium.io')
+ local crds
+ for crd in "${crds[@]}"
+ kubectl get crd ciliuml2announcementpolicies.cilium.io
+ sleep 5
+ kubectl get crd ciliuml2announcementpolicies.cilium.io
+ sleep 5
```
After patch:
```
$ task bootstrap:apps
...
task: [bootstrap:apps] helmfile --file [REDACTED]/kubernetes/bootstrap/apps/helmfile.yaml apply --skip-diff-on-install --suppress-diff
...
Listing releases matching ^flux-operator$
Listing releases matching ^flux-instance$
Upgrading release=cilium, chart=cilium/cilium, namespace=kube-system
Release "cilium" does not exist. Installing it now.
...
```
The expected CRD manifests from Cilium config exists as expected after this.
```

