### PR TITLE
fix(helmfile): move cilium bootstrap hooks to postsync

### DIFF
--- a/templates/config/kubernetes/bootstrap/apps/helmfile.yaml.j2
+++ b/templates/config/kubernetes/bootstrap/apps/helmfile.yaml.j2
@@ -26,7 +26,7 @@ releases:
     version: 1.17.0
     values: ['{{ requiredEnv "KUBERNETES_DIR" }}/apps/kube-system/cilium/app/helm-values.yaml']
     hooks:
-      - events: ['presync']
+      - events: ['postsync']
         command: bash
         args: ['{{ requiredEnv "KUBERNETES_DIR" }}/bootstrap/apps/hooks/cilium-config.sh']
 


### PR DESCRIPTION
Using presync hook block the install of cilium (and the whole bootstrap task) as CRD are not installed in the cluster.