### PR TITLE
Add back missing newline in github-deploy-key

### DIFF
--- a/templates/config/bootstrap/github-deploy-key.sops.yaml.j2
+++ b/templates/config/bootstrap/github-deploy-key.sops.yaml.j2
@@ -9,7 +9,7 @@ stringData:
   identity: |
     #% filter indent(width=4, first=False) %#
     #{ github_deploy_key() }#
-    #%- endfilter %#
+    #% endfilter %#
   known_hosts: |
     github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
     github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=


### PR DESCRIPTION
In #1791 a `strip()` was added to a bunch of strings read from files. However, this also removes newlines, so for the github-deploy-key the `known_hosts` would end up on the same line as the end of the private key and therefore not work in the `source-controller`.

Instead of removing the `strip()` let's remove the `-` sign in the jinja end block so we keep newline after it.