### PR TITLE
Fix: Allow secureboot and encrypt_disk fields to be optional

### DIFF
--- a/.taskfiles/template/resources/nodes.schema.cue
+++ b/.taskfiles/template/resources/nodes.schema.cue
@@ -15,14 +15,14 @@ import (
 }
 
 #Node: {
-	name:         =~"^[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9]$|^[a-z0-9]$" & !="global" & !="controller" & !="worker"
-	address:      net.IPv4
-	controller:   bool
-	disk:         string
-	mac_addr:     =~"^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$"
-	schematic_id: =~"^[a-z0-9]{64}$"
-	mtu?:         >=1450 & <=9000
-	secureboot?:  bool
+	name:          =~"^[a-z0-9][a-z0-9\\-]{0,61}[a-z0-9]$|^[a-z0-9]$" & !="global" & !="controller" & !="worker"
+	address:       net.IPv4
+	controller:    bool
+	disk:          string
+	mac_addr:      =~"^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$"
+	schematic_id:  =~"^[a-z0-9]{64}$"
+	mtu?:          >=1450 & <=9000
+	secureboot?:   bool
 	encrypt_disk?: bool
 }
 

--- a/.taskfiles/template/resources/nodes.schema.cue
+++ b/.taskfiles/template/resources/nodes.schema.cue
@@ -22,6 +22,8 @@ import (
 	mac_addr:     =~"^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$"
 	schematic_id: =~"^[a-z0-9]{64}$"
 	mtu?:         >=1450 & <=9000
+	secureboot?:  bool
+	encrypt_disk?: bool
 }
 
 #Config


### PR DESCRIPTION
Updated the node schema to add optioanal secureboot and encrypt_disk fields in schema.