### PR TITLE
fix: make hsts-max-age well formed

### DIFF
--- a/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
@@ -53,7 +53,7 @@ spec:
         enable-real-ip: "true"
         force-ssl-redirect: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: "31449600"
+        hsts-max-age: "31449600" # quote
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"

--- a/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
@@ -53,7 +53,7 @@ spec:
         enable-real-ip: "true"
         force-ssl-redirect: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: 31449600
+        hsts-max-age: "31449600"
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"

--- a/templates/config/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml.j2
@@ -50,7 +50,7 @@ spec:
         enable-real-ip: "true"
         force-ssl-redirect: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: 31449600
+        hsts-max-age: "31449600"
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"

--- a/templates/config/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/internal/ingress-nginx/helmrelease.yaml.j2
@@ -50,7 +50,7 @@ spec:
         enable-real-ip: "true"
         force-ssl-redirect: "true"
         hide-headers: Server,X-Powered-By
-        hsts-max-age: "31449600"
+        hsts-max-age: "31449600" # quote
         keep-alive-requests: 10000
         keep-alive: 120
         log-format-escape-json: "true"


### PR DESCRIPTION
When value is high header has scientific notation value

ex: `max-age=1.5552e+07; includeSubDomains`.

Which is not valid according to following  

https://datatracker.ietf.org/doc/html/rfc6797#section-6.1.1
