### PR TITLE
Make bash and gsed brew availability check Intel Mac compatible

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -24,7 +24,7 @@ tasks:
     cmd: bash {{.SCRIPTS_DIR}}/bootstrap-apps.sh
     preconditions:
       - msg: Unsupported bash version, run `brew install bash` to upgrade
-        sh: '{{if eq OS "darwin"}}test -f /opt/homebrew/bin/bash{{end}}'
+        sh: '{{if eq OS "darwin"}}test -f /opt/homebrew/bin/bash || test -f /usr/local/bin/bash{{end}}'
       - test -f {{.KUBECONFIG}}
       - test -f {{.ROOT_DIR}}/.sops.yaml
       - test -f {{.SCRIPTS_DIR}}/bootstrap-apps.sh

--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -156,7 +156,7 @@ tasks:
         sh: which gsed || which sed
     preconditions:
       - msg: Unsupported sed version, run `brew install gsed` to upgrade
-        sh: '{{if eq OS "darwin"}}test -f /opt/homebrew/bin/gsed{{end}}'
+        sh: '{{if eq OS "darwin"}}test -f /opt/homebrew/bin/gsed || test -f /usr/local/bin/gsed{{end}}'
       - test -d {{.ROOT_DIR}}/.taskfiles/template
       - test -d {{.TEMPLATE_DIR}}
       - test -f {{.MAKEJINJA_CONFIG_FILE}}


### PR DESCRIPTION
- On Intel Mac the homebrew binaries are located at /usr/local/bin/ instead of /opt/homebrew/bin, let's include the Intel Mac path in the check as well.
- See https://docs.brew.sh/Installation for more details on possible install configurations.
- Checking the actual versions of these binaries would be better but this works fine for now.