### PR TITLE
fix: move installation of crds to bootstrap script

### DIFF
--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -23,7 +23,7 @@ function wait_for_nodes() {
     done
 }
 
-# The application namespaces are created before applying the resources
+# Namespaces to be applied before the SOPS secrets are installed
 function apply_namespaces() {
     log debug "Applying namespaces"
 
@@ -84,6 +84,30 @@ function apply_sops_secrets() {
     done
 }
 
+# CRDs to be applied before the helmfile charts are installed
+function apply_crds() {
+    log debug "Applying CRDs"
+
+    local -r crds=(
+        # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+        https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml
+        # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
+        https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.81.0/stripped-down-crds.yaml
+    )
+
+    for crd in "${crds[@]}"; do
+        if kubectl diff --filename "${crd}" &>/dev/null; then
+            log info "CRDs are up-to-date" "crd=${crd}"
+            continue
+        fi
+        if kubectl apply --server-side --filename "${crd}" &>/dev/null; then
+            log info "CRDs applied" "crd=${crd}"
+        else
+            log error "Failed to apply CRDs" "crd=${crd}"
+        fi
+    done
+}
+
 # Apply Helm releases using helmfile
 function apply_helm_releases() {
     log debug "Applying Helm releases with helmfile"
@@ -108,6 +132,7 @@ function main() {
     wait_for_nodes
     apply_namespaces
     apply_sops_secrets
+    apply_crds
     apply_helm_releases
 
     log info "Congrats! The cluster is bootstrapped and Flux is syncing the Git repository"

--- a/templates/config/talos/patches/controller/cluster.yaml.j2
+++ b/templates/config/talos/patches/controller/cluster.yaml.j2
@@ -19,8 +19,3 @@ cluster:
   scheduler:
     extraArgs:
       bind-address: 0.0.0.0
-  extraManifests:
-    - # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
-      https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
-    - # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
-      https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.80.1/stripped-down-crds.yaml


### PR DESCRIPTION
The way Talos handles `extraManifests` is quite odd. Talos may potentially downgrade the items in `extraManifests` if the cluster admin **did not apply the talos config** after merging the PR that upgrades the CRDs in the `extraManifests`. This isn't ideal so I've moved them back into the bootstrap script.

Moving forward I would rather support only having these crds be applied on bootstrap and then the cluster taking over the management lifecycle and not deal with the nuances of `extraManifests`