### PR TITLE
feat: remove global postbuild patch

### DIFF
--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -93,6 +93,8 @@ function apply_crds() {
         https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/experimental-install.yaml
         # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
         https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.81.0/stripped-down-crds.yaml
+        # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns
+        https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/v0.16.0/docs/sources/crd/crd-manifest.yaml
     )
 
     for crd in "${crds[@]}"; do

--- a/templates/config/kubernetes/apps/cert-manager/cert-manager/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/cert-manager/cert-manager/ks.yaml.j2
@@ -16,6 +16,10 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -46,6 +50,10 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/tls
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/default/echo/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/default/echo/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/default/echo/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/flux-system/flux-instance/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/flux-system/flux-instance/ks.yaml.j2
@@ -14,6 +14,10 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/flux-system/flux-operator/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/flux-system/flux-operator/ks.yaml.j2
@@ -16,6 +16,10 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/kube-system/cilium/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/cilium/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/kube-system/coredns/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/coredns/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/kube-system/metrics-server/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/metrics-server/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/kube-system/reloader/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/reloader/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/kube-system/spegel/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/spegel/ks.yaml.j2
@@ -12,6 +12,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/network/external/external-dns/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/external/external-dns/helmrelease.yaml.j2
@@ -15,12 +15,10 @@ spec:
         name: external-dns
         namespace: flux-system
   install:
-    crds: CreateReplace
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
     remediation:
       strategy: rollback
       retries: 3

--- a/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
+++ b/templates/config/kubernetes/apps/network/external/ingress-nginx/helmrelease.yaml.j2
@@ -21,9 +21,6 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
-  dependsOn:
-    - name: cloudflared
-      namespace: network
   values:
     fullnameOverride: external-ingress-nginx
     controller:

--- a/templates/config/kubernetes/apps/network/external/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/network/external/ks.yaml.j2
@@ -11,6 +11,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/external/external-dns
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -31,11 +35,12 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
-  dependsOn:
-    - name: external-external-dns
-      namespace: network
   interval: 1h
   path: ./kubernetes/apps/network/external/cloudflared
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -61,6 +66,10 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/external/ingress-nginx
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/apps/network/internal/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/network/internal/ks.yaml.j2
@@ -14,6 +14,10 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/internal/ingress-nginx
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -36,6 +40,10 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/internal/k8s-gateway
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/templates/config/kubernetes/flux/cluster/ks.yaml.j2
+++ b/templates/config/kubernetes/flux/cluster/ks.yaml.j2
@@ -39,14 +39,6 @@ spec:
   interval: 1h
   path: ./kubernetes/apps
   prune: true
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
-        optional: false
-      - name: cluster-settings
-        kind: ConfigMap
-        optional: true
   retryInterval: 2m
   sourceRef:
     kind: GitRepository
@@ -64,14 +56,6 @@ spec:
             provider: sops
             secretRef:
               name: sops-age
-          postBuild:
-            substituteFrom:
-              - name: cluster-secrets
-                kind: Secret
-                optional: false
-              - name: cluster-settings
-                kind: ConfigMap
-                optional: true
       target:
         group: kustomize.toolkit.fluxcd.io
         kind: Kustomization


### PR DESCRIPTION
- That patch ended up interfering with postBuilds set on individual app ks
- Install external-dns endpoint CRD on bootstrap (this never changes and removes some dependsOn)