### PR TITLE
Add back read permission in flux-local workflow

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -45,6 +45,7 @@ jobs:
     needs: pre-job
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     strategy:
       matrix:


### PR DESCRIPTION
- Read permissions are needed for private repos, and was actually initially added in #1742.
- This was removed in a refactor in #1791, let's add it back so it works with private repos again.