### PR TITLE
feat(cilium): update BGP configuration to use cluster config and peer settings

### DIFF
--- a/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
@@ -25,25 +25,65 @@ spec:
       kubernetes.io/os: linux
 #% if cilium_bgp_enabled %#
 ---
-# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumbgppeeringpolicy_v2alpha1.json
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpclusterconfig_v2alpha1.json
 apiVersion: cilium.io/v2alpha1
-kind: CiliumBGPPeeringPolicy
+kind: CiliumBGPClusterConfig
 metadata:
-  name: l3-policy
+  name: cilium-bgp
 spec:
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux
-  virtualRouters:
-    - localASN: #{ cilium_bgp_node_asn }#
-      exportPodCIDR: false
-      serviceSelector:
+  bgpInstances:
+    - name: instance-#{ cilium_bgp_router_asn }#
+      localASN: #{ cilium_bgp_router_asn }#
+      peers:
+        - name: peer-#{ cilium_bgp_node_asn }#-udmp-v4
+          peerASN: #{ cilium_bgp_node_asn }#
+          peerAddress: #{ cilium_bgp_router_addr }#
+          peerConfigRef:
+            name: cilium-peer-v4
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgppeerconfig_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  name: cilium-peer-v4
+spec:
+  timers:
+    keepAliveTimeSeconds: 3
+    holdTimeSeconds: 9
+    connectRetryTimeSeconds: 12
+  gracefulRestart:
+    enabled: true
+    restartTimeSeconds: 15
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchExpressions:
+          - key: advertise
+            operator: In
+            values:
+              - bgp
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpadvertisement_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  name: lb-services
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+    - advertisementType: "Service"
+      service:
+        addresses:
+          - LoadBalancerIP
+      selector:
         matchExpressions:
           - key: thisFakeSelector
             operator: NotIn
             values:
-              - will-match-and-announce-all-services
-      neighbors:
-        - peerAddress: "#{ cilium_bgp_router_addr }#/32"
-          peerASN: #{ cilium_bgp_router_asn }#
+              - never-used-value
 #% endif %#

--- a/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/cilium/app/networks.yaml.j2
@@ -25,11 +25,41 @@ spec:
       kubernetes.io/os: linux
 #% if cilium_bgp_enabled %#
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpclusterconfig_v2alpha1.json
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumbgpadvertisement_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPAdvertisement
+metadata:
+  name: bgp-advertisement-config
+  labels:
+    advertise: bgp
+spec:
+  advertisements:
+    - advertisementType: Service
+      service:
+        addresses:
+          - LoadBalancerIP
+      selector:
+        matchExpressions:
+          - { key: somekey, operator: NotIn, values: ["never-used-value"] }
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumbgppeerconfig_v2alpha1.json
+apiVersion: cilium.io/v2alpha1
+kind: CiliumBGPPeerConfig
+metadata:
+  name: bgp-peer-config-v4
+spec:
+  families:
+    - afi: ipv4
+      safi: unicast
+      advertisements:
+        matchLabels:
+          advertise: bgp
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliumbgpclusterconfig_v2alpha1.json
 apiVersion: cilium.io/v2alpha1
 kind: CiliumBGPClusterConfig
 metadata:
-  name: cilium-bgp
+  name: bgp-cluster-config
 spec:
   nodeSelector:
     matchLabels:
@@ -38,52 +68,9 @@ spec:
     - name: instance-#{ cilium_bgp_router_asn }#
       localASN: #{ cilium_bgp_router_asn }#
       peers:
-        - name: peer-#{ cilium_bgp_node_asn }#-udmp-v4
+        - name: peer-#{ cilium_bgp_node_asn }#-v4
           peerASN: #{ cilium_bgp_node_asn }#
           peerAddress: #{ cilium_bgp_router_addr }#
           peerConfigRef:
-            name: cilium-peer-v4
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgppeerconfig_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumBGPPeerConfig
-metadata:
-  name: cilium-peer-v4
-spec:
-  timers:
-    keepAliveTimeSeconds: 3
-    holdTimeSeconds: 9
-    connectRetryTimeSeconds: 12
-  gracefulRestart:
-    enabled: true
-    restartTimeSeconds: 15
-  families:
-    - afi: ipv4
-      safi: unicast
-      advertisements:
-        matchExpressions:
-          - key: advertise
-            operator: In
-            values:
-              - bgp
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumbgpadvertisement_v2alpha1.json
-apiVersion: cilium.io/v2alpha1
-kind: CiliumBGPAdvertisement
-metadata:
-  name: lb-services
-  labels:
-    advertise: bgp
-spec:
-  advertisements:
-    - advertisementType: "Service"
-      service:
-        addresses:
-          - LoadBalancerIP
-      selector:
-        matchExpressions:
-          - key: thisFakeSelector
-            operator: NotIn
-            values:
-              - never-used-value
+            name: bgp-peer-config-v4
 #% endif %#


### PR DESCRIPTION
Update `CiliumBGPPeeringPolicy` to BGP V2 `CiliumBGPClusterConfig`, `CiliumBGPPeerConfig`, `CiliumBGPAdvertisement`.

Ties to discussion:
#1855 