### PR TITLE
chore(external-dns): update CRD path

### DIFF
--- a/scripts/bootstrap-apps.sh
+++ b/scripts/bootstrap-apps.sh
@@ -92,7 +92,7 @@ function apply_crds() {
         # renovate: datasource=github-releases depName=prometheus-operator/prometheus-operator
         https://github.com/prometheus-operator/prometheus-operator/releases/download/v0.82.2/stripped-down-crds.yaml
         # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns
-        https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/v0.17.0/docs/sources/crd/crd-manifest.yaml
+        https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/tags/v0.17.0/config/crd/standard/dnsendpoint.yaml
     )
 
     for crd in "${crds[@]}"; do


### PR DESCRIPTION
CRD path was changed in https://github.com/kubernetes-sigs/external-dns/pull/5287 it seems