### PR TITLE
fix: set token permissions for label-sync

### DIFF
--- a/.github/workflows/label-sync.yaml
+++ b/.github/workflows/label-sync.yaml
@@ -12,6 +12,9 @@ jobs:
   label-sync:
     name: Label Sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Fix for `Error: ✗ {"message":"Resource not accessible by integration","statusCode":403, ...}` on new repositories.