### PR TITLE
fix labeler permissions

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Labeler
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0


### PR DESCRIPTION
this should fix an error I hit here: https://github.com/hef/house-cluster/actions/runs/16392247611/job/46319757253#step:2:9

```
{"resource":"Repository","field":"label","code":"unauthorized"}
Error: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
```