### PR TITLE
Revert "feat: use gcr mirror for docker.io pulls"

### DIFF
--- a/templates/config/talos/patches/global/machine-registries.yaml.j2
+++ b/templates/config/talos/patches/global/machine-registries.yaml.j2
@@ -1,6 +1,0 @@
-machine:
-  registries:
-    mirrors:
-      docker.io:
-        endpoints:
-          - https://mirror.gcr.io


### PR DESCRIPTION
Reverts onedr0p/cluster-template#1946

This does not work with spegel