### PR TITLE
Use ed25519 to generate deploy-key

### DIFF
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -38,7 +38,7 @@ tasks:
 
   generate-deploy-key:
     internal: true
-    cmd: ssh-keygen -t ecdsa -b 521 -C "deploy-key" -f {{.ROOT_DIR}}/github-deploy.key -q -P ""
+    cmd: ssh-keygen -t ed25519 -C "deploy-key" -f {{.ROOT_DIR}}/github-deploy.key -q -P ""
     status:
       - test -f {{.ROOT_DIR}}/github-deploy.key
     preconditions:


### PR DESCRIPTION
GitHub recommends using Ed25519, as you can see [here](https://docs.github.com/de/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).

Tested it and works without any problems in my cluster (with a private repo)