### PR TITLE
fix(container): Align network kustomizations with oher ones

### DIFF
--- a/templates/config/kubernetes/apps/network/cloudflare-dns/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/network/cloudflare-dns/ks.yaml.j2
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-dns
+  path: ./kubernetes/apps/network/cloudflare-dns/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/templates/config/kubernetes/apps/network/cloudflare-tunnel/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/network/cloudflare-tunnel/ks.yaml.j2
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 1h
-  path: ./kubernetes/apps/network/cloudflare-tunnel
+  path: ./kubernetes/apps/network/cloudflare-tunnel/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets

--- a/templates/config/kubernetes/apps/network/k8s-gateway/ks.yaml.j2
+++ b/templates/config/kubernetes/apps/network/k8s-gateway/ks.yaml.j2
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   interval: 1h
-  path: ./kubernetes/apps/network/k8s-gateway
+  path: ./kubernetes/apps/network/k8s-gateway/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets


### PR DESCRIPTION
It took me the whole day to find out that the kustomization was referencing itself incorrectly due to the missing `/app` in the path, and the changes https://github.com/onedr0p/cluster-template/pull/1969 were not applied correctly. 

I'm not a flux expert, as I'm using it for a few days with your template, but without these changes a
`kubernetes/apps/network/k8s-gateway Kustomization: network/k8s-gateway Kustomization: network/k8s-gateway` (same for cloudflare-dns and cloudflare-tunnel) were created, which (I assume) have overwritten the changes in 
`kubernetes/apps Kustomization: flux-system/cluster-apps Kustomization: network/k8s-gateway`
and the patch for sops decryption will only be applied to `kubernetes/apps`

I hope I explained it enough so you can follow the changes :) Otherwise, feel free to ask

Just out of curiosity (and I know a PR is not the right place to ask), how are you testing the changes in your home ops?
I'm just asking because I applied the latest changes from this template today. After merging and flux applied them to my cluster, I found out that the network pods were not coming up anymore. So I reverted them and started debugging.
I'm wondering if there is maybe a better pattern to test things, which I also should apply :) Btw, thanks a lot for this amazing template :)