### PR TITLE
fix(talos): admissionControl patch

### DIFF
--- a/templates/config/talos/patches/controller/admission-controller-patch.yaml.j2
+++ b/templates/config/talos/patches/controller/admission-controller-patch.yaml.j2
@@ -1,2 +1,0 @@
-- op: remove
-  path: /cluster/apiServer/admissionControl

--- a/templates/config/talos/patches/controller/cluster.yaml.j2
+++ b/templates/config/talos/patches/controller/cluster.yaml.j2
@@ -1,6 +1,8 @@
 cluster:
   allowSchedulingOnControlPlanes: true
   apiServer:
+    admissionControl:
+      $$patch: delete
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true


### PR DESCRIPTION
This is not working anymore:
```yaml
op: remove
```

```
  ⎿  Error: 2025/10/25 12:03:58 failed to generate talos config: JSON6902 patches are not supported for multi-document machine configuration
     error: Recipe `gen-config` failed on line 30 with exit code 1
```

See https://github.com/budimanjojo/talhelper/issues/1226