### PR TITLE
template Taskfile.yaml - talenv.sops.yaml patch

### DIFF
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -93,7 +93,7 @@ tasks:
     cmds:
       - for: { var: SECRET_FILES }
         cmd: |
-          if sops filestatus "{{.ITEM}}" | jq --exit-status ".encrypted == false" &>/dev/null; then
+          if [ $(sops filestatus "{{.ITEM}}" | jq ".encrypted") == "false" ]; then
               sops --encrypt --in-place "{{.ITEM}}"
           fi
     vars:


### PR DESCRIPTION
The current command used in the [task: template:encrypt-secrets task](https://github.com/onedr0p/cluster-template/blob/main/.taskfiles/template/Taskfile.yaml#L96) doesn't allow re-running `task: configure` if the talhelper default `talenv.sops.yaml` is added to the talos directory. The `template:encrypt-secrets` task fails to encrypt the file as does the whole configure run.

Changing the logic a little still allows the command to return successfully and properly sops encrypt the file while allowing the whole configure run to succeed.

Example:
Follow all the steps for bootstrapping a cluster.
```
$ export REPONAME="test"
$ gh repo create $REPONAME --template onedr0p/cluster-template --disable-wiki --public --clone && cd $REPONAME
$ mise trust
$ pip install pipx
$ mise install
$ cloudflared tunnel login
$ cloudflared tunnel create --credentials-file cloudflare-tunnel.json kubernetes
$ task init
$ task configure
$ git add -A
$ git commit -m "chore: initial commit :rocket:"
$ git push
$ task bootstrap:talos
```

Add a secret environment variable to `talos/talenv.sops.yaml` [example values from talhelper](https://github.com/budimanjojo/talhelper/blob/194ec71f8cf71d9de16e9da9005a2a0371d41c15/example/talconfig.yaml#L147C1-L155C47)
```
$ echo 'wgPrivateKey: 6NtibgkNWGSLp7ud6NgZr9k3kNhlQiaJCVW6vN+j9UY=' >> talos/talenv.sops.yaml
$ echo 'wgPublicKey: kyiu4YOZqX+7tY4fdiIRNDe2lSEvlun76EWtD/jP1hU=' >> talos/talenv.sops.yaml
```

Add a talos patch to `envsubst` the encrypted variable references into the machine config.
```
$ mkdir talos/patches/node1/
$ nano talos/patches/node1/wireguard.yaml
- op: add
  path: /machine/network/interfaces/0/wireguard
  value:
    privateKey: ${wgPrivateKey}
    listenPort: 51111
    peers:
      - publicKey: ${wgPublicKey}
        endpoint: 192.168.1.3:1111
        allowedIPs:
          - 192.168.1.0/24
        persistentKeepaliveInterval: 10s
$ nano talos/talconfig.yaml
$ git diff talos/talconfig.yaml
...
+    patches:
+      - "@./patches/talos/wireguard.yaml"
...
```

The `task: configure` run fails right after the `talsecret.sops.yaml` file is checked for encryption.
```
$ task configure -y
Any conflicting files in the kubernetes directory will be overwritten... continue? [assuming yes]
...
task: [template:encrypt-secrets] if sops filestatus "/path/to/repo/talos/talsecret.sops.yaml" | jq --exit-status ".encrypted == false" &>/dev/null; then
    sops --encrypt --in-place "/path/to/repo/talos/talsecret.sops.yaml"
fi

task: Failed to run task "configure": exit status 1
```

The new `talenv.sops.yaml` file remains **unencrypted**.
```
$ sops filestatus talos/talenv.sops.yaml
{"encrypted":false}
```

Apply the suggested patch.
```
$ nano .taskfiles/template/Taskfile.yaml
$ git diff .taskfiles/template/Taskfile.yaml
diff --git a/.taskfiles/template/Taskfile.yaml b/.taskfiles/template/Taskfile.yaml
index c6bda4c..f689747 100644
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -93,7 +93,7 @@ tasks:
     cmds:
       - for: { var: SECRET_FILES }
         cmd: |
-          if sops filestatus "{{.ITEM}}" | jq --exit-status ".encrypted == false" &>/dev/null; then
+          if [ $(sops filestatus "{{.ITEM}}" | jq ".encrypted") == "false" ]; then
               sops --encrypt --in-place "{{.ITEM}}"
           fi
     vars:
```

Re-run `task: configure` successfully.
```
$ task configure -y
...
task: [template:encrypt-secrets] if [ $(sops filestatus "/path/to/repo/talos/talsecret.sops.yaml" | jq ".encrypted") == "false" ]; then
    sops --encrypt --in-place "/path/to/repo/talos/talsecret.sops.yaml"
fi

task: [template:encrypt-secrets] if [ $(sops filestatus "/path/to/repo/talos/talenv.sops.yaml" | jq ".encrypted") == "false" ]; then
    sops --encrypt --in-place "/path/to/repo/talos/talenv.sops.yaml"
fi

task: [template:validate-kubernetes-config] bash /path/to/repo/.taskfiles/template/resources/kubeconform.sh /path/to/repo/kubernetes
...
Your talhelper config file is looking great!
```

And now the newly added `talenv.sops.yaml` file is successfully **encrypted**.
```
$ sops filestatus talos/talenv.sops.yaml
{"encrypted":true}
```