### PR TITLE
Add mise-vscode extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "blueglassblock.better-json5",
     "irongeek.vscode-env",
     "redhat.vscode-yaml",
-    "signageos.signageos-vscode-sops"
+    "signageos.signageos-vscode-sops",
+    "hverlin.mise-vscode"
   ]
 }


### PR DESCRIPTION
Add mise-vscode extension as recommended - it helps ensure binaries installed by mise are used.  

Fixes ENOENT errors if using vscode-sops to manage secrets.