### PR TITLE
Add permissions for release job in workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Get Previous Release Tag and Determine Next Tag
         id: determine-next-tag


### PR DESCRIPTION
The [release job](https://github.com/onedr0p/cluster-template/blob/main/.github/workflows/release.yaml) in the Github Actions workflow requires "content: write" permission to be able to create new releases. Otherwise your job errors with:
`Error: Error 403: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#generate-release-notes-content-for-a-release`.

This is documented in the `ncipollo/release-action` [job example](https://github.com/ncipollo/release-action/blob/main/README.md#example) and [notes](https://github.com/ncipollo/release-action/blob/main/README.md#notes).

A workaround is enabling "Workflow permissions: Read and write permissions" at https://github.com/owner/repo/settings/actions. This may not be ideal for all workflows as it enables it by default for all github actions workflow jobs.