### PR TITLE
feat: add `kernel_modules` argument to talconfig

### DIFF
--- a/.github/tests/nodes.yaml
+++ b/.github/tests/nodes.yaml
@@ -14,3 +14,6 @@ nodes:
     mtu: 1500
     secureboot: true
     encrypt_disk: true
+    kernel_modules:
+      - nvidia
+      - nvidia_uvm

--- a/.taskfiles/template/resources/nodes.schema.cue
+++ b/.taskfiles/template/resources/nodes.schema.cue
@@ -21,9 +21,10 @@ import (
 	disk:          string
 	mac_addr:      =~"^([0-9a-f]{2}[:]){5}([0-9a-f]{2})$"
 	schematic_id:  =~"^[a-z0-9]{64}$"
-	mtu?:          >=1450 & <=9000
-	secureboot?:   bool
-	encrypt_disk?: bool
+	mtu?:            >=1450 & <=9000
+	secureboot?:     bool
+	encrypt_disk?:   bool
+	kernel_modules?: [...string]
 }
 
 #Config

--- a/nodes.sample.yaml
+++ b/nodes.sample.yaml
@@ -9,4 +9,5 @@ nodes: []
   #   mtu: 1500           # (ADVANCED/OPTIONAL) MTU for the NIC. DEFAULT: 1500
   #   secureboot: false   # (ADVANCED/OPTIONAL) SecureBoot mode on UEFI platforms. Ref: https://www.talos.dev/latest/talos-guides/install/bare-metal-platforms/secureboot
   #   encrypt_disk: false # (ADVANCED/OPTIONAL) TPM-based disk encryption. Ref: https://www.talos.dev/latest/talos-guides/install/bare-metal-platforms/secureboot
+  #   kernel_modules: []  # (ADVANCED/OPTIONAL) Only applicable if the `schematic_id` you've provided contains system extensions that require kernel modules to correctly load - Example: ["nvidia", "nvidia_uvm", "nvidia_drm", "nvidia_modeset", "zfs"]
   # ...

--- a/templates/config/talos/talconfig.yaml.j2
+++ b/templates/config/talos/talconfig.yaml.j2
@@ -64,8 +64,9 @@ nodes:
         #% endif %#
         #% endif %#
     #% if talos_patches('%s' % (item.name)) | length == 0 %#
-    #% if item.encrypt_disk | default(false, true) %#
+    #% if item.encrypt_disk | default(false, true) or (item.kernel_modules | default([], true) | length > 0) %#
     patches:
+    #% if item.encrypt_disk | default(false, true) %#
       - # Encrypt system disk with TPM
         |-
         machine:
@@ -80,6 +81,17 @@ nodes:
               keys:
                 - slot: 0
                   tpm: {}
+    #% endif %#
+    #% if item.kernel_modules | default([], true) | length > 0 %#
+      - # Load kernel modules
+        |-
+        machine:
+          kernel:
+            modules:
+              #% for module in item.kernel_modules %#
+              - name: #{ module }#
+              #% endfor %#
+    #% endif %#
     #% endif %#
     #% else %#
     #% for file in talos_patches('%s' % (item.name)) %#
@@ -99,6 +111,15 @@ nodes:
               keys:
                 - slot: 0
                   tpm: {}
+    #% endif %#
+    #% if item.kernel_modules | default([], true) | length > 0 %#
+      - |-
+        machine:
+          kernel:
+            modules:
+              #% for module in item.kernel_modules %#
+              - name: #{ module }#
+              #% endfor %#
     #% endif %#
     #% endif %#
       - "@./patches/#{ item.name }#/#{ file | basename }#"


### PR DESCRIPTION
Closes https://github.com/onedr0p/cluster-template/issues/2075

This enables nodes that are bootstrapped with specific kernel module requirements specified in their respective schematic ID to be correct and matching the requirements.