### PR TITLE
Update talhelper version to 3.0.44

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -7,7 +7,7 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 [tools]
 "python" = "3.14.2"
 "pipx:makejinja" = "2.8.2"
-"aqua:budimanjojo/talhelper" = "3.0.43"
+"aqua:budimanjojo/talhelper" = "3.0.44"
 "aqua:cilium/cilium-cli" = "0.18.9"
 "aqua:cli/cli" = "2.83.2"
 "aqua:cloudflare/cloudflared" = "2025.11.1"


### PR DESCRIPTION
Updated talhelper version from 3.0.43 to 3.0.44 - this is required for talos 1.12.0

Fixes: 

```task: [template:validate-talos-config] talhelper validate talconfig <snip>/talos/talconfig.yaml
There are issues with your talhelper config file:
field: "talosVersion"
  * WARNING: "v1.12.0" might not be compatible with this Talhelper version you're using```