### PR TITLE
fix(talos): add default route configuration

### DIFF
--- a/templates/config/talos/talconfig.yaml.j2
+++ b/templates/config/talos/talconfig.yaml.j2
@@ -45,6 +45,7 @@ nodes:
             mtu: #{ item.mtu | default(1500, true) }#
             routes:
               - gateway: "#{ node_default_gateway }#"
+                network: 0.0.0.0/0
             #% if item.controller %#
             vip:
               ip: "#{ cluster_api_addr }#"
@@ -55,6 +56,7 @@ nodes:
           - "#{ item.address }#/#{ node_cidr.split('/') | last }#"
         routes:
           - gateway: "#{ node_default_gateway }#"
+            network: 0.0.0.0/0
         mtu: #{ item.mtu | default(1500, true) }#
         #% if item.controller %#
         vip:


### PR DESCRIPTION
without `network: 0.0.0.0/0` assigned to the route we get generated...
```yaml
---
apiVersion: v1alpha1
kind: LinkConfig
name: ethSel0
mtu: 1500
addresses:
  - address: 10.10.10.100/24
```
but adding in `network: 0.0.0.0/0` to the route we get
```yaml
---
apiVersion: v1alpha1
kind: LinkConfig
name: ethSel0
mtu: 1500
addresses:
  - address: 10.10.10.100/24
routes:
  - gateway: 10.10.10.1
```