### PR TITLE
chore: add uv and pipx to mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -6,6 +6,8 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 
 [tools]
 "python" = "3.14.2"
+"uv" = "0.9.28"
+"pipx" = "1.8.0"
 "pipx:makejinja" = "2.8.2"
 "aqua:budimanjojo/talhelper" = "3.1.3"
 "aqua:cilium/cilium-cli" = "0.19.0"


### PR DESCRIPTION
Added uv, pipx, and other tool versions to .mise.toml