### PR TITLE
chore: remove templating tools in mise with tidy

### DIFF
--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -131,8 +131,8 @@ tasks:
       - which kubectl
 
   tidy:
-    desc: Archive template related files and directories
-    prompt: All files and directories related to the templating process will be archived... continue?
+    desc: Archive or remove all template related config
+    prompt: All template related config will be archived or removed... continue?
     cmds:
       - mkdir -p {{.TIDY_FOLDER}}
       - rm -rf {{.ROOT_DIR}}/.github/tests


### PR DESCRIPTION
Running tidy should also remove tools no longer required in mise.toml, let's also remove the .venv folder too.