### PR TITLE
chore: set SOPS_CONFIG

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,7 @@
 [env]
 _.python.venv = { path = "{{config_root}}/.venv", create = true } # required:template
 KUBECONFIG = "{{config_root}}/kubeconfig"
+SOPS_CONFIG = "{{config_root}}/.sops.yaml"
 SOPS_AGE_KEY_FILE = "{{config_root}}/age.key"
 TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 

--- a/.taskfiles/template/Taskfile.yaml
+++ b/.taskfiles/template/Taskfile.yaml
@@ -59,8 +59,6 @@ tasks:
       - task: validate-kubernetes-config
       - task: validate-talos-config
     preconditions:
-      - msg: An existing Age key interferes with the age key in this repository, rename or delete ~/.config/sops/age/keys.txt
-        sh: '! test -f ~/.config/sops/age/keys.txt'
       - msg: File cluster.yaml not found, did you run `task init`?
         sh: test -f {{.TEMPLATE_CONFIG_FILE}}
       - msg: File nodes.yaml not found, did you run `task init`?


### PR DESCRIPTION
ISSUE: I have struggled with my own SOPS_CONFIG that was taken from $HOME all the time together with SOPS_AGE_KEY_FILE that was local. Sops couldn't decrypt the files both in tasks and in vs code.

SOLUTION: Instead of mentioning _"rename or delete ~/.config/sops/age/keys.txt"_ in template Taskfile.yaml we can specify both envs in **.mise.toml** that fully override all other options and we can omit specifying those across task files or anywhere else (tested this). Just one place to specify and they will work everywhere provided mise works as it should. I think this is cleaner and way more straight-forward option to cut all issues with sops configuration at once.

Is there any chance that you haven't specified it here for some reason?