### PR TITLE
feat: generate post-quantum age keys for SOPS

### DIFF
--- a/template/mod.just
+++ b/template/mod.just
@@ -58,7 +58,7 @@ doctor:
 [group('template')]
 init:
     [ -f "{{ config_file }}" ]     || cp "{{ sample_config_file }}" "{{ config_file }}"
-    [ -f "$SOPS_AGE_KEY_FILE" ]    || age-keygen --output "$SOPS_AGE_KEY_FILE"
+    [ -f "$SOPS_AGE_KEY_FILE" ]    || age-keygen -pq --output "$SOPS_AGE_KEY_FILE"
     [ -f "{{ deploy_key }}" ]      || ssh-keygen -t ed25519 -C "deploy-key" -f "{{ deploy_key }}" -q -P ""
     [ -f "{{ push_token_file }}" ] || openssl rand -hex 16 > "{{ push_token_file }}"
 

--- a/template/scripts/plugin.py
+++ b/template/scripts/plugin.py
@@ -31,12 +31,14 @@ def age_key(key_type: str, file_path: str = 'age.key') -> str:
         with open(file_path, 'r') as file:
             file_content = file.read().strip()
         if key_type == 'public':
+            # Matches both classic (age1...) and post-quantum (age1pq1...) recipients
             key_match = re.search(r"# public key: (age1[\w]+)", file_content)
             if not key_match:
                 raise ValueError("Could not find public key in the age key file.")
             return key_match.group(1)
         elif key_type == 'private':
-            key_match = re.search(r"(AGE-SECRET-KEY-[\w]+)", file_content)
+            # (?:PQ-)? matches post-quantum identities (AGE-SECRET-KEY-PQ-1...) as well as classic ones
+            key_match = re.search(r"(AGE-SECRET-KEY-(?:PQ-)?1[\w]+)", file_content)
             if not key_match:
                 raise ValueError("Could not find private key in the age key file.")
             return key_match.group(1)


### PR DESCRIPTION
## What

Switch `just init` to `age-keygen -pq` so **new clusters generate a hybrid post-quantum age key** (ML-KEM-768 + X25519, "X-Wing" over HPKE) and encrypt their SOPS secrets to a quantum-resistant recipient at rest.

Also fix a latent bug in `age_key()` (`template/scripts/plugin.py`) that only surfaces with PQ keys — see below.

## Why

Recent releases wired native post-quantum support through the whole stack **that this template already pins**:

| Component | First PQ version | Pinned here |
|---|---|---|
| [age](https://github.com/FiloSottile/age/releases/tag/v1.3.0) — native hybrid ML-KEM-768 + X25519 recipients | **v1.3.0** (Dec 2025) | `1.3.1` ✅ |
| [SOPS](https://github.com/getsops/sops) — embeds age's PQ cipher | **v3.12.0** (Feb 2026) | `3.13.2` ✅ |
| [Flux](https://github.com/fluxcd/flux2/releases/tag/v2.9.0) — "SOPS decryption with the Age post-quantum cipher (`Kustomization`)" | **v2.9.0** | `2.9.0` ✅ |
| kustomize-controller — decrypts PQ in-process (go.mod: age 1.3.1, sops 3.13.1) | **v1.9.0** | via flux-operator `0.53.0` → dist `v2.9.0` ✅ |

Because PQ lives in the `filippo.io/age` **library** and is statically linked into both the `sops` CLI and kustomize-controller, **no `age-plugin-pq` binary is required anywhere** — not locally, not baked into the Flux image. Adopting PQ was purely a matter of *using* the capability, not upgrading to get it.

This is **at-rest** PQ (your secrets in Git). It's unrelated to **in-transit** PQ (Go's `X25519MLKEM768` TLS for HTTPS OCI/artifact pulls), which is already automatic and needs no config; the `ssh://` Git sync isn't TLS and is untouched.

## Changes

- **`template/mod.just`** — `age-keygen --output …` → `age-keygen -pq --output …`.
- **`template/scripts/plugin.py`** — the private-key regex `AGE-SECRET-KEY-[\w]+` **silently truncated** a PQ identity to `AGE-SECRET-KEY-PQ` (the `-` before `PQ-1…` isn't a word char), rendering a broken key into both `.sops.yaml` and the in-cluster `sops-age` Secret with no error raised. Now `AGE-SECRET-KEY-(?:PQ-)?1[\w]+`, which handles PQ **and** classic identities. The public-key regex (`age1[\w]+`) already matches `age1pq1…` unchanged.

## Verification

With the pinned toolchain (`age` 1.3.1, `sops` 3.13.x):

- `age-keygen -pq` → `age1pq1…` recipient (~1959 chars) + `AGE-SECRET-KEY-PQ-1…` identity.
- Patched `age_key()` extracts the **full** public and private keys for both PQ and classic keys (classic unchanged — no regression).
- Full `sops` round-trip using the template's exact rules (`encrypted_regex: ^(data|stringData)$`, `mac_only_encrypted: true`) against a real `age1pq1…` recipient: encrypt (plaintext gone) → decrypt (recovered). ✅

The e2e workflow exercises this automatically: `just init` (now `-pq`) → `just configure` (renders via the patched `age_key()`) → bootstrap.

---

## Migrating an existing cluster to PQ

New clusters are automatic. Existing clusters keep their classic key until you opt in — here's how.

> [!IMPORTANT]
> **Prerequisite — confirm the running kustomize-controller is v1.9.0+.** PQ decryption happens in the controller, and its age/sops version comes from the deployed image, *not* from your local `.mise` pins. If it's older, **PQ-sealed secrets will fail to decrypt cluster-wide.** Upgrade Flux to 2.9.0+ (flux-operator ≥ 0.53.0) first.
> ```sh
> kubectl -n flux-system get deploy kustomize-controller \
>   -o jsonpath='{.spec.template.spec.containers[0].image}{"\n"}'
> # expect ghcr.io/fluxcd/kustomize-controller:v1.9.x
> ```

### Option A — zero-downtime (recommended)

Add the PQ key *alongside* your classic key so every secret is decryptable by either during the transition, then drop the classic key once healthy.

```sh
# 1. Generate a PQ keypair (kept separate for now)
age-keygen -pq -o age-pq.key

# 2. Add BOTH recipients to .sops.yaml (comma-separated), e.g.
#      age: "age1<classic>,age1pq1<new>"
#    then re-wrap the data key of every secret to both recipients
find . -name '*.sops.yaml' -exec sops updatekeys -y {} \;

# 3. Give the controller BOTH identities so it can decrypt either.
#    kustomize-controller reads every AGE-SECRET-KEY-* line in the Secret value,
#    so append the PQ identity to the sops-age Secret:
kubectl -n flux-system get secret sops-age -o jsonpath='{.data.age\.agekey}' | base64 -d > /tmp/agekey
grep 'AGE-SECRET-KEY-PQ-' age-pq.key >> /tmp/agekey
kubectl -n flux-system create secret generic sops-age \
  --from-file=age.agekey=/tmp/agekey --dry-run=client -o yaml | kubectl apply -f -
# (or edit bootstrap/sops-age.sops.yaml to hold both keys and re-apply)

# 4. Commit + push. Flux reconciles cleanly (decrypts with either key). Verify:
flux get kustomizations -A   # all Ready

# 5. Once healthy, go PQ-only: remove the classic recipient from .sops.yaml,
#    re-run `sops updatekeys` on all files, drop the classic identity from the
#    Secret, and replace age.key with the PQ key (so `just configure` renders PQ).
mv age-pq.key age.key
find . -name '*.sops.yaml' -exec sops updatekeys -y {} \;
```

### Option B — simple hard swap (brief reconcile hiccup)

Fine for a home cluster where a short window of un-decryptable secrets is acceptable.

```sh
# 1. Replace your key with a PQ one
age-keygen -pq -o age.key

# 2. Point .sops.yaml at the new age1pq1… recipient and rotate every secret's data key
find . -name '*.sops.yaml' -exec sops rotate -i {} \;   # after updating .sops.yaml

# 3. Update the in-cluster sops-age Secret with the new AGE-SECRET-KEY-PQ-1… identity
#    (kubectl apply the re-encrypted bootstrap/sops-age.sops.yaml, or recreate the Secret)

# 4. Commit + push
```

### Caveats

- **Hybrid, so classic isn't broken.** Classic X25519 already resists everything short of a large future quantum computer; PQ only closes the "harvest-now-decrypt-later" gap. Deferring on a home cluster is reasonable — there's no functional loss staying classic.
- **New key material required.** You can't convert a classic key to PQ; anyone with your old `age.key` + Git history can still read pre-rotation secrets. Rotate + re-encrypt if that matters.
- **~2000-char recipients** make `.sops.yaml` and secret headers noticeably noisier.
- **Talos:** the `talos/*.sops.yaml` files (full-file encrypted, e.g. `talsecret.sops.yaml`) are covered by the same `.sops.yaml` rules and re-encrypt the same way.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
