### PR TITLE
ci: replace flux-local with flate in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,6 +94,8 @@ jobs:
 
       - name: Install flate
         uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
+        with:
+          base: "" # e2e renders a fresh, untracked tree — full-tree test, not changed-only (no resolvable base)
 
       - name: Run flate test
         run: flate test all -p ./kubernetes/flux/cluster

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,10 +92,11 @@ jobs:
       - name: Run configure recipe
         run: just configure
 
-      - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v8.3.0@sha256:dca65e5bcd71cb904216774ebfbc5d1f30a36d0b304293b851dfed2385c01b0c
-        with:
-          args: test --enable-helm --all-namespaces --path /github/workspace/kubernetes/flux/cluster -v
+      - name: Install flate
+        uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
+
+      - name: Run flate test
+        run: flate test all -p ./kubernetes/flux/cluster
 
       - name: Dry run bootstrap talos recipe
         run: just --dry-run bootstrap talos

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Install flate
         uses: home-operations/flate/action@0fc37fae10cf3c265294f6adebc6d6c100c74ea5 # v0.4.10
         with:
-          base: "" # e2e renders a fresh, untracked tree — full-tree test, not changed-only (no resolvable base)
+          base: ""
 
       - name: Run flate test
         run: flate test all -p ./kubernetes/flux/cluster

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Kubernetes
 kubeconfig
 talosconfig
+# Python
+__pycache__/
+*.py[cod]
 # Misc.
 .claude/
 .private/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - Dev env managed w/ [mise](https://mise.jdx.dev/)
 - Workflow automation w/ [GitHub Actions](https://github.com/features/actions)
 - Dependency automation w/ [Renovate](https://www.mend.io/renovate)
-- Flux `HelmRelease` and `Kustomization` diffs w/ [flux-local](https://github.com/allenporter/flux-local)
+- Flux `HelmRelease` and `Kustomization` diffs w/ [flate](https://github.com/home-operations/flate)
 
 Does this sound cool to you? If so, continue to read on! 👇
 


### PR DESCRIPTION
Replaces `flux-local` with [flate](https://github.com/home-operations/flate) in the E2E `validate-valid` job, aligning it with the existing `flate.yaml` workflow so the repo uses a single Flux validation tool.

## Changes

- **`.github/workflows/e2e.yaml`** — swap the `flux-local` docker action for the pinned flate action (`home-operations/flate/action@…# v0.4.10`) + `flate test all -p ./kubernetes/flux/cluster`. `flate test all` is the equivalent of flux-local's `test --enable-helm --all-namespaces` — it reconciles the full graph and tests HelmReleases and Kustomizations across all namespaces.
- **`.gitignore`** — ignore `__pycache__/` and `*.py[cod]`. These are generated whenever makejinja imports `template/scripts/plugin.py` during `just configure`, and were previously showing up as untracked noise.
- **`README.md`** — update the diff-tooling feature reference from flux-local to flate.
