### PR TITLE
fix: modernize justfiles and fix broken bare module listing

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,6 @@
 set quiet
+set minimum-version := '1.55.1'
+set default-list
 set shell := ['bash', '-euo', 'pipefail', '-c']
 set script-interpreter := ['bash', '-euo', 'pipefail']
 
@@ -10,10 +12,6 @@ mod? kube 'kubernetes'
 
 [group: 'talos']
 mod? talos 'talos'
-
-[private]
-default:
-    just -l
 
 [private]
 log lvl msg *args:

--- a/template/config/bootstrap/mod.just
+++ b/template/config/bootstrap/mod.just
@@ -2,12 +2,9 @@ set no-exit-message
 set quiet
 set shell := ['bash', '-euo', 'pipefail', '-c']
 set script-interpreter := ['bash', '-euo', 'pipefail']
+set default-list
 
 kubernetes_dir := justfile_dir() + '/kubernetes'
-
-[private]
-default:
-    just bootstrap -l
 
 [doc('Bootstrap the Talos cluster')]
 [group('bootstrap')]

--- a/template/config/kubernetes/mod.just
+++ b/template/config/kubernetes/mod.just
@@ -1,10 +1,7 @@
 set quiet
 set shell := ['bash', '-euo', 'pipefail', '-c']
 set script-interpreter := ['bash', '-euo', 'pipefail']
-
-[private]
-default:
-    just kube -l
+set default-list
 
 [doc('Force Flux to pull in changes from your Git repository')]
 [group('kube')]

--- a/template/config/talos/mod.just
+++ b/template/config/talos/mod.just
@@ -1,10 +1,7 @@
 set quiet
 set shell := ['bash', '-euo', 'pipefail', '-c']
 set script-interpreter := ['bash', '-euo', 'pipefail']
-
-[private]
-default:
-    just talos -l
+set default-list
 
 [doc('Apply Talos config to a node')]
 [group('talos')]
@@ -23,7 +20,7 @@ reset:
     talhelper gencommand reset \
         --extra-flags="--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash
 
-[confirm("This will reset the specified node to maintenance mode — continue? [y/N]")]
+[confirm("This will reset node " + ip + " to maintenance mode and wipe STATE + EPHEMERAL — continue? [y/N]")]
 [doc('Reset a single node back to maintenance mode (DESTRUCTIVE)')]
 [group('talos')]
 reset-node ip:

--- a/template/mod.just
+++ b/template/mod.just
@@ -1,4 +1,5 @@
 set quiet
+set default-list
 set shell := ['bash', '-euo', 'pipefail', '-c']
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set working-directory := '..'
@@ -19,10 +20,6 @@ deploy_key := justfile_dir() + '/github-deploy.key'
 push_token_file := justfile_dir() + '/github-push-token.txt'
 cloudflare_tunnel := justfile_dir() + '/cloudflare-tunnel.json'
 
-[private]
-default:
-    just template -l
-
 [doc('Render and validate configuration files')]
 [group('template')]
 configure: configure-preconditions render encrypt-secrets validate-kubernetes validate-talos
@@ -33,6 +30,7 @@ configure: configure-preconditions render encrypt-secrets validate-kubernetes va
 [script]
 doctor:
     rc=0
+    just log info "just version" version "{{ just_version() }}"
     just template doctor-check "cluster.toml"           "{{ config_file }}"           || rc=1
     just template doctor-check "cluster.sample.toml"    "{{ sample_config_file }}"    || rc=1
     just template doctor-check "cloudflare-tunnel.json" "{{ cloudflare_tunnel }}"     || rc=1
@@ -93,9 +91,14 @@ doctor-check label path:
 encrypt-secrets:
     find "{{ bootstrap_dir }}" "{{ kubernetes_dir }}" "{{ talos_dir }}" -type f -name '*.sops.*' -print0 \
         | while IFS= read -r -d '' f; do
-            if [ "$(sops filestatus "$f" | jq '.encrypted')" = "false" ]; then
-                sops --encrypt --in-place "$f"
+            if ! status="$(sops filestatus "$f" | jq -r '.encrypted')"; then
+                just log fatal "could not read encryption status" file "$f"
             fi
+            case "$status" in
+                false) sops --encrypt --in-place "$f" ;;
+                true)  : ;;
+                *)     just log fatal "could not determine encryption status" file "$f" ;;
+            esac
         done
 
 [private]


### PR DESCRIPTION
Reviewed recent `just` releases against our justfiles (repo pins `just 1.55.1`). The justfiles were already near state-of-the-art, so these are targeted hardening changes plus one real bug fix. Every change was verified against `just 1.55.1`.

## Changes

**1. `set default-list` on all modules — fixes broken bare `just <mod>`**
Each module carried a `[private] default:` recipe whose body was `just <mod> -l`. That command errors on 1.55.1 — bare `just kube` / `just talos` / `just bootstrap` fail with `justfile does not contain recipe '<mod> -l'`. `set default-list` (stable since 1.52.0) lists natively and removes the shim (and its hardcoded module name). This also lands in every downstream cluster rendered from the template.

```
$ just kube        # before: error: justfile does not contain recipe `kube -l`
$ just kube        # after:  Available recipes: … reconcile
```

**2. `encrypt-secrets` fails closed on unexpected SOPS status** (`template/mod.just`)
Previously `[ "$(sops filestatus … | jq '.encrypted')" = "false" ]`: if `sops`/`jq` errored or returned anything but literal `false`, the file was silently treated as already-encrypted — a plaintext secret could get committed. Now classifies `true`/`false`/other explicitly and hard-fails on the unknown case. (Verified across plaintext → encrypt, encrypted → skip, and sops-error/malformed/empty → fatal.)

**3. `reset-node` names the target IP in its confirm prompt** (`template/config/talos/mod.just`)
The one destructive recipe whose blast radius is a parameter now states it: `This will reset node <ip> to maintenance mode and wipe STATE + EPHEMERAL — continue?` (`[confirm]` expression, stable since 1.49.0).

**4. `set minimum-version := '1.55.1'`** (root `justfile`)
Fails loudly on an old `just` binary instead of relying only on the mise pin, and self-documents the floor. (Stable since 1.55.0.)

**5. `doctor` logs the running `just` version** via `just_version()` (1.55.0) — small observability win for the common mise-pin-vs-system confusion; additive, can't affect the exit code.

## Notes
- All changes use **stable** `just` features — nothing here depends on `JUST_UNSTABLE=1`.
- The mixed `[group: '…']` (modules) vs `[group('…')]` (recipes) attribute syntax was **intentionally left as-is**: it's already what `just --fmt` canonicalizes to (colon for module attributes, parens for recipe attributes), so "standardizing" it would fight the formatter.
- Verified: all five justfiles parse on `just 1.55.1`, bare `just`/`just <mod>` list correctly, and `format-just` (lefthook) is clean.
