### PR TITLE
chore(mise): drop python and pipx from the toolchain

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -1,5 +1,4 @@
 [env]
-_.python.venv = { path = "{{config_root}}/.venv", create = true } # required:template
 KUBECONFIG = "{{config_root}}/kubeconfig"
 SOPS_CONFIG = "{{config_root}}/.sops.yaml"
 SOPS_AGE_KEY_FILE = "{{config_root}}/age.key"
@@ -7,9 +6,7 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 JUST_UNSTABLE = "1"
 
 [tools]
-python = "3.14.6"          # required:template
 uv = "0.11.29"             # required:template
-pipx = "1.16.0"            # required:template
 "pipx:makejinja" = "2.8.2" # required:template
 age = "1.3.1"
 cloudflared = "2026.7.2"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -585,82 +585,9 @@ provenance = "github-attestations"
 version = "0.59.0"
 backend = "npm:oxfmt"
 
-[[tools.pipx]]
-version = "1.16.0"
-backend = "aqua:pypa/pipx"
-
-[tools.pipx."platforms.linux-arm64"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
-[tools.pipx."platforms.linux-arm64-musl"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
-[tools.pipx."platforms.linux-x64"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
-[tools.pipx."platforms.linux-x64-musl"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
-[tools.pipx."platforms.macos-arm64"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
-[tools.pipx."platforms.macos-x64"]
-checksum = "sha256:2b4931409f31d679ecd7cd03c92d7df58f14d32f37145cd109054830d31b0f6f"
-url = "https://github.com/pypa/pipx/releases/download/1.16.0/pipx.pyz"
-url_api = "https://api.github.com/repos/pypa/pipx/releases/assets/478552145"
-
 [[tools."pipx:makejinja"]]
 version = "2.8.2"
 backend = "pipx:makejinja"
-
-[[tools.python]]
-version = "3.14.6"
-backend = "core:python"
-
-[tools.python."platforms.linux-arm64"]
-checksum = "sha256:c2a2caa03aa9beb77a5bbb5a009c8fe77b96a56925da2dba18095237e30faf04"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.linux-arm64-musl"]
-checksum = "sha256:ff7da86be2a3d7fdf0124da7b408ad2de3c7ca8d6c19e6c449ec2cddedd01a8b"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-aarch64-unknown-linux-musl-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.linux-x64"]
-checksum = "sha256:86bf107f65fc30b56f2b263b26797fcbb1661f5315910cdbf27f733eb8738b74"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.linux-x64-musl"]
-checksum = "sha256:2c27fc15bde497fbd78a8d5d38559ee1a8c93110952d5c2b390bc6481e2be415"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-unknown-linux-musl-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.macos-arm64"]
-checksum = "sha256:5e8e0746cb0108d138f510cfbb28c4b031b9ed63bbbe3e43a34c77d4663c4fa1"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-aarch64-apple-darwin-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.macos-x64"]
-checksum = "sha256:2d03154bc83c6d2d048bba23bb808b020e352028f5bd541a740e54467fc9cc75"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-apple-darwin-install_only_stripped.tar.gz"
-provenance = "github-attestations"
-
-[tools.python."platforms.windows-x64"]
-checksum = "sha256:0c5c9f231704fb49149bc8f2b9d9dbe43eeaf6c54f362ef0fc2066ce64b4d10f"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260718/cpython-3.14.6+20260718-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
-provenance = "github-attestations"
 
 [[tools.sd]]
 version = "1.1.0"

--- a/README.md
+++ b/README.md
@@ -86,13 +86,10 @@ These guidelines provide a strong baseline, but there are always exceptions and 
 
     ```sh
     mise trust
-    pip install pipx
     mise install
     ```
 
     📍 _**Having trouble installing the tools?** Try unsetting the `GITHUB_TOKEN` env var and then run these commands again_
-
-    📍 _**Having trouble compiling Python?** Try running `mise settings python.compile=0` and then run these commands again_
 
 5. Logout of the GitHub Container Registry as this may cause authorization problems in future steps when using the public registry:
 

--- a/template/mod.just
+++ b/template/mod.just
@@ -118,7 +118,6 @@ tidy-archive:
     mv "{{ makejinja_config }}"     "$TIDY_FOLDER/makejinja.toml"
     mv "{{ config_file }}"          "$TIDY_FOLDER/cluster.toml"
     mv "{{ sample_config_file }}"   "$TIDY_FOLDER/cluster.sample.toml"
-    mv "{{ justfile_dir() }}/.venv" "$TIDY_FOLDER/.venv"
 
 [private]
 tidy-preconditions:

--- a/template/mod.just
+++ b/template/mod.just
@@ -127,9 +127,9 @@ tidy-preconditions:
 
 [private]
 tidy-strip:
-    sd '\..\.j2'                       '' "{{ justfile_dir() }}/.renovaterc.json5"
-    sd '(?ms)^# === template ===$.*'   '' "{{ justfile_dir() }}/justfile"
-    sd '.*required:template.*\n'       '' "{{ justfile_dir() }}/.mise/config.toml"
+    sd '\..\.j2'                          '' "{{ justfile_dir() }}/.renovaterc.json5"
+    sd -A '(?ms)^# === template ===$.*'   '' "{{ justfile_dir() }}/justfile"
+    sd -A '.*required:template.*\n'       '' "{{ justfile_dir() }}/.mise/config.toml"
 
 [private]
 validate-kubernetes:


### PR DESCRIPTION
## Summary

Removes `python`, `pipx` and the project venv from the required toolchain. mise's pipx backend uses `uv tool install` when uv is available (`pipx.uvx` defaults to `true`), and uv provisions its own prebuilt interpreter, so makejinja needs neither a mise-managed Python nor the pipx binary.

- `.mise/config.toml`: drop `python`, `pipx` and the `_.python.venv` activation (the venv was vestigial; nothing in the render pipeline uses it — `plugin.py` executes inside makejinja's own uv-managed environment)
- `template/mod.just`: `tidy-archive` no longer moves a `.venv` that no longer exists
- README: drop the `pip install pipx` step and the "trouble compiling Python" tip (uv downloads prebuilt CPython, nothing compiles)

## Verification

- Local: clean reinstall of `pipx:makejinja` with this config goes through `uv tool`; full `just init` + `just configure` (render, sops encrypt, kubeconform, talhelper) passes with no `.venv` created and no `pipx` on PATH
- Scratch clone: `just template reset` + `just template tidy` complete with the archive containing template/, makejinja.toml and the config files
- Clean-room: full flow in a `debian:bookworm-slim` container (no Python in the image, none installed via apt): mise installed the toolchain, uv downloaded its managed `cpython-3.14.6`, and `just configure` passed; `python` never appeared on PATH

## Also fixed: tidy-strip was silently a no-op for line removals

Pre-existing bug reproducible on main: sd processes input line by line by default, so the two multi-line patterns in tidy-strip (justfile template-section removal, `required:template` line removal) could never match and left their targets intact. sd's `-A/--across` flag processes the input as a whole and makes the existing patterns work unchanged. Verified in a scratch clone running configure → reset → tidy: all three strips apply and the tidied justfile still parses (`just --list`).

## Notes (pre-existing, not addressed here)

- `oxfmt` is npm-backed, giving the toolchain an implicit node dependency (surfaced by the container test; fine on GitHub runners which ship node).
