### PR TITLE
feat(template): harden config schema validation

### DIFF
--- a/.github/tests/invalid/bad-bgp-asn.toml
+++ b/.github/tests/invalid/bad-bgp-asn.toml
@@ -1,0 +1,32 @@
+# Negative fixture: BGP router ASN above the 32-bit ASN range.
+# Expected to be rejected by _router_asn_in_range.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[cilium.bgp]
+router_addr = "10.10.1.1"
+router_asn  = "4294967296"
+node_asn    = "64514"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/bad-vlan-tag.toml
+++ b/.github/tests/invalid/bad-vlan-tag.toml
@@ -1,0 +1,28 @@
+# Negative fixture: vlan_tag outside the valid 1-4094 range.
+# Expected to be rejected by _vlan_tag_in_range.
+[network]
+node_cidr = "10.10.10.0/24"
+vlan_tag  = "5000"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/gateway-node-collision.toml
+++ b/.github/tests/invalid/gateway-node-collision.toml
@@ -1,0 +1,27 @@
+# Negative fixture: a node reuses the internal gateway VIP.
+# Expected to be rejected by _addr_uniqueness_check.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.252"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/nested-cidr-overlap.toml
+++ b/.github/tests/invalid/nested-cidr-overlap.toml
@@ -1,0 +1,28 @@
+# Negative fixture: node_cidr is nested inside the default pod_cidr
+# (10.42.0.0/16) without being string-equal to it.
+# Expected to be rejected by _cidr_overlap_check.
+[network]
+node_cidr = "10.42.128.0/17"
+
+[kubernetes.api]
+addr = "10.42.128.254"
+
+[gateways]
+internal = "10.42.128.252"
+dns      = "10.42.128.253"
+external = "10.42.128.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.42.128.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/node-addr-outside-cidr.toml
+++ b/.github/tests/invalid/node-addr-outside-cidr.toml
@@ -1,0 +1,27 @@
+# Negative fixture: node address is not inside network.node_cidr.
+# Expected to be rejected by _node_addrs_in_node_cidr.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "192.168.1.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/node-uses-gateway-addr.toml
+++ b/.github/tests/invalid/node-uses-gateway-addr.toml
@@ -1,0 +1,28 @@
+# Negative fixture: a node claims the default gateway address (defaults to
+# the first IP in node_cidr).
+# Expected to be rejected by _addr_uniqueness_check.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.1"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/non-canonical-cidr.toml
+++ b/.github/tests/invalid/non-canonical-cidr.toml
@@ -1,0 +1,28 @@
+# Negative fixture: node_cidr written with host bits set instead of the
+# network address.
+# Expected to be rejected by _cidr_canonical_check.
+[network]
+node_cidr = "10.10.10.5/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/invalid/tiny-svc-cidr.toml
+++ b/.github/tests/invalid/tiny-svc-cidr.toml
@@ -1,0 +1,31 @@
+# Negative fixture: svc_cidr too small to contain the derived CoreDNS
+# address (10th IP).
+# Expected to be rejected by _coredns_addr_in_svc_cidr.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes]
+svc_cidr = "10.43.0.0/29"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cloudflare]
+domain = "example.com"
+token  = "fake"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,6 +30,8 @@ jobs:
         fixture:
           - overlapping-cidrs
           - nested-cidr-overlap
+          - non-canonical-cidr
+          - tiny-svc-cidr
           - duplicate-gateway-addrs
           - duplicate-node-names
           - reserved-node-name
@@ -37,6 +39,7 @@ jobs:
           - bad-repo-url
           - missing-known-hosts
           - node-addr-outside-cidr
+          - node-uses-gateway-addr
           - gateway-node-collision
           - bad-vlan-tag
           - bad-bgp-asn

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,12 +29,17 @@ jobs:
       matrix:
         fixture:
           - overlapping-cidrs
+          - nested-cidr-overlap
           - duplicate-gateway-addrs
           - duplicate-node-names
           - reserved-node-name
           - bad-mac-address
           - bad-repo-url
           - missing-known-hosts
+          - node-addr-outside-cidr
+          - gateway-node-collision
+          - bad-vlan-tag
+          - bad-bgp-asn
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -62,6 +62,11 @@ node_cidr = ""
 
 # svc_cidr = "10.43.0.0/16"
 
+# ClusterIP for the CoreDNS Service. Must be inside svc_cidr.
+# OPTIONAL. Default: the 10th IP in svc_cidr
+
+# coredns_addr = ""
+
 [kubernetes.api]
 
 # Virtual IP for the Kubernetes API server. kubectl, flux, and every other

--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -34,7 +34,7 @@ node_cidr = ""
 
 # 802.1Q VLAN tag to apply to the Talos node interface. Only set this if
 # your switch ports are configured as trunks (passing tagged traffic to the
-# nodes); access ports already untag VLAN traffic.
+# nodes); access ports already untag VLAN traffic. Must be 1-4094.
 # REF: https://www.talos.dev/latest/advanced/advanced-networking/#vlans
 # OPTIONAL.
 

--- a/template/config/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
@@ -17,7 +17,7 @@ spec:
       create: true
     service:
       name: kube-dns
-      clusterIP: "#{ kubernetes.svc_cidr | nthhost(10) }#"
+      clusterIP: "#{ kubernetes.coredns_addr }#"
     replicaCount: 2
     servers:
       - zones:

--- a/template/resources/config.schema.cue
+++ b/template/resources/config.schema.cue
@@ -19,27 +19,40 @@ import (
 	spegel_enabled:     bool | *(len(nodes) > 1)
 	cilium_bgp_enabled: cilium.bgp.router_addr != "" && cilium.bgp.router_asn != "" && cilium.bgp.node_asn != ""
 
+	let _node_base = strings.Split(network.node_cidr, "/")[0]
+	let _pod_base = strings.Split(kubernetes.pod_cidr, "/")[0]
+	let _svc_base = strings.Split(kubernetes.svc_cidr, "/")[0]
+
+	// CIDRs must be written in network-address form (no host bits set), since
+	// derived addresses offset from the base IP. A canonical base minus one
+	// lands outside the CIDR; a base with host bits set does not.
+	_cidr_canonical_check: {
+		node_cidr_has_host_bits: false & net.InCIDR(net.AddIP(_node_base, -1), network.node_cidr)
+		pod_cidr_has_host_bits:  false & net.InCIDR(net.AddIP(_pod_base, -1), kubernetes.pod_cidr)
+		svc_cidr_has_host_bits:  false & net.InCIDR(net.AddIP(_svc_base, -1), kubernetes.svc_cidr)
+	}
+
 	// The node, pod and service CIDRs must not overlap. Checking containment
 	// of each network address catches nested ranges, not just equal strings.
 	_cidr_overlap_check: {
-		node_cidr_overlaps_pod_cidr: false
-		node_cidr_overlaps_pod_cidr: net.InCIDR(strings.Split(network.node_cidr, "/")[0], kubernetes.pod_cidr) || net.InCIDR(strings.Split(kubernetes.pod_cidr, "/")[0], network.node_cidr)
-		node_cidr_overlaps_svc_cidr: false
-		node_cidr_overlaps_svc_cidr: net.InCIDR(strings.Split(network.node_cidr, "/")[0], kubernetes.svc_cidr) || net.InCIDR(strings.Split(kubernetes.svc_cidr, "/")[0], network.node_cidr)
-		pod_cidr_overlaps_svc_cidr:  false
-		pod_cidr_overlaps_svc_cidr:  net.InCIDR(strings.Split(kubernetes.pod_cidr, "/")[0], kubernetes.svc_cidr) || net.InCIDR(strings.Split(kubernetes.svc_cidr, "/")[0], kubernetes.pod_cidr)
+		node_cidr_overlaps_pod_cidr: false & (net.InCIDR(_node_base, kubernetes.pod_cidr) || net.InCIDR(_pod_base, network.node_cidr))
+		node_cidr_overlaps_svc_cidr: false & (net.InCIDR(_node_base, kubernetes.svc_cidr) || net.InCIDR(_svc_base, network.node_cidr))
+		pod_cidr_overlaps_svc_cidr:  false & (net.InCIDR(_pod_base, kubernetes.svc_cidr) || net.InCIDR(_svc_base, kubernetes.pod_cidr))
 	}
 
-	// The API VIP, gateway VIPs and node addresses must all be distinct.
-	_addr_uniqueness_check: list.UniqueItems() & list.Concat([
-		[kubernetes.api.addr, gateways.internal, gateways.dns, gateways.external],
-		[for n in nodes {n.address}],
-	])
+	// The API VIP, gateway VIPs, default gateway and node addresses must all
+	// be distinct.
+	_addr_uniqueness_check: list.UniqueItems() & [
+		kubernetes.api.addr, gateways.internal, gateways.dns, gateways.external, network.default_gateway,
+		for n in nodes {n.address},
+	]
 
-	// Node addresses, the API VIP and the default gateway live in the node network.
+	// Node addresses, the API VIP and the default gateway live in the node
+	// network; the CoreDNS address lives in the service network.
 	_node_addrs_in_node_cidr: [for n in nodes {true & net.InCIDR(n.address, network.node_cidr)}]
 	_api_addr_in_node_cidr:        true & net.InCIDR(kubernetes.api.addr, network.node_cidr)
 	_default_gateway_in_node_cidr: true & net.InCIDR(network.default_gateway, network.node_cidr)
+	_coredns_addr_in_svc_cidr:     true & net.InCIDR(kubernetes.coredns_addr, kubernetes.svc_cidr)
 
 	// Without BGP the gateway VIPs are announced over L2 and must also live
 	// in the node network.
@@ -67,8 +80,7 @@ import (
 	// VLAN tag for the Talos nodes (rare). Must be 1-4094.
 	vlan_tag?: =~"^[0-9]+$"
 	if vlan_tag != _|_ {
-		_vlan_tag_in_range: >=1 & <=4094
-		_vlan_tag_in_range: strconv.Atoi(vlan_tag)
+		_vlan_tag_in_range: strconv.Atoi(vlan_tag) & >=1 & <=4094
 	}
 }
 
@@ -77,8 +89,8 @@ import (
 	pod_cidr: *"10.42.0.0/16" | net.IPCIDR
 	// The service CIDR for the cluster, /16 recommended.
 	svc_cidr: *"10.43.0.0/16" | net.IPCIDR
-	// CoreDNS service address, the 10th IP in svc_cidr.
-	coredns_addr: net.AddIP(strings.Split(svc_cidr, "/")[0], 10)
+	// IP handed to the CoreDNS Service (defaults to the 10th IP in svc_cidr).
+	coredns_addr: net.IPv4 & !="" | *net.AddIP(strings.Split(svc_cidr, "/")[0], 10)
 	api: {
 		// The IP address of the Kube API.
 		addr: net.IPv4
@@ -140,15 +152,12 @@ _known_ssh_hosts: ["github.com", "gitlab.com", "codeberg.org"]
 		router_addr: *"" | net.IPv4 & !=""
 		// The BGP router ASN (1-4294967295).
 		router_asn: *"" | =~"^[0-9]+$"
-		if router_asn != "" {
-			_router_asn_in_range: >=1 & <=4294967295
-			_router_asn_in_range: strconv.Atoi(router_asn)
-		}
 		// The BGP node ASN (1-4294967295).
 		node_asn: *"" | =~"^[0-9]+$"
-		if node_asn != "" {
-			_node_asn_in_range: >=1 & <=4294967295
-			_node_asn_in_range: strconv.Atoi(node_asn)
+		_asn_range_check: {
+			for name, value in {router: router_asn, node: node_asn} if value != "" {
+				(name): strconv.Atoi(value) & >=1 & <=4294967295
+			}
 		}
 	}
 }

--- a/template/resources/config.schema.cue
+++ b/template/resources/config.schema.cue
@@ -3,6 +3,7 @@ package config
 import (
 	"net"
 	"list"
+	"strconv"
 	"strings"
 )
 
@@ -18,20 +19,35 @@ import (
 	spegel_enabled:     bool | *(len(nodes) > 1)
 	cilium_bgp_enabled: cilium.bgp.router_addr != "" && cilium.bgp.router_asn != "" && cilium.bgp.node_asn != ""
 
-	// Pairwise CIDR uniqueness. We can't use list.UniqueItems on these because
-	// kubernetes.pod_cidr/svc_cidr are defaulted disjunctions (`*"…" | net.IPCIDR`),
-	// and CUE evaluates the list constraint against the unresolved disjunction —
-	// so the defaulted values silently slip through. Pairwise `!=` works.
-	network: node_cidr: !=kubernetes.pod_cidr & !=kubernetes.svc_cidr
-	kubernetes: pod_cidr: !=network.node_cidr & !=kubernetes.svc_cidr
-	kubernetes: svc_cidr: !=network.node_cidr & !=kubernetes.pod_cidr
+	// The node, pod and service CIDRs must not overlap. Checking containment
+	// of each network address catches nested ranges, not just equal strings.
+	_cidr_overlap_check: {
+		node_cidr_overlaps_pod_cidr: false
+		node_cidr_overlaps_pod_cidr: net.InCIDR(strings.Split(network.node_cidr, "/")[0], kubernetes.pod_cidr) || net.InCIDR(strings.Split(kubernetes.pod_cidr, "/")[0], network.node_cidr)
+		node_cidr_overlaps_svc_cidr: false
+		node_cidr_overlaps_svc_cidr: net.InCIDR(strings.Split(network.node_cidr, "/")[0], kubernetes.svc_cidr) || net.InCIDR(strings.Split(kubernetes.svc_cidr, "/")[0], network.node_cidr)
+		pod_cidr_overlaps_svc_cidr:  false
+		pod_cidr_overlaps_svc_cidr:  net.InCIDR(strings.Split(kubernetes.pod_cidr, "/")[0], kubernetes.svc_cidr) || net.InCIDR(strings.Split(kubernetes.svc_cidr, "/")[0], kubernetes.pod_cidr)
+	}
 
-	_addrs_check: list.UniqueItems() & [
-		kubernetes.api.addr, gateways.internal, gateways.dns, gateways.external,
-	]
+	// The API VIP, gateway VIPs and node addresses must all be distinct.
+	_addr_uniqueness_check: list.UniqueItems() & list.Concat([
+		[kubernetes.api.addr, gateways.internal, gateways.dns, gateways.external],
+		[for n in nodes {n.address}],
+	])
+
+	// Node addresses, the API VIP and the default gateway live in the node network.
+	_node_addrs_in_node_cidr: [for n in nodes {true & net.InCIDR(n.address, network.node_cidr)}]
+	_api_addr_in_node_cidr:        true & net.InCIDR(kubernetes.api.addr, network.node_cidr)
+	_default_gateway_in_node_cidr: true & net.InCIDR(network.default_gateway, network.node_cidr)
+
+	// Without BGP the gateway VIPs are announced over L2 and must also live
+	// in the node network.
+	if !cilium_bgp_enabled {
+		_gateways_in_node_cidr: [for g in [gateways.internal, gateways.dns, gateways.external] {true & net.InCIDR(g, network.node_cidr)}]
+	}
 
 	_node_name_check: list.UniqueItems() & [for n in nodes {n.name}]
-	_node_addr_check: list.UniqueItems() & [for n in nodes {n.address}]
 	_node_mac_check:  list.UniqueItems() & [for n in nodes {n.mac_addr}]
 
 	network: dns_servers: *["1.1.1.1", "1.0.0.1"] | _
@@ -47,9 +63,13 @@ import (
 	// NTP servers to use for the cluster (default: ["162.159.200.1", "162.159.200.123"]).
 	ntp_servers: [...net.IPv4]
 	// The default gateway for the nodes (defaults to the first IP in node_cidr).
-	default_gateway?: net.IPv4 & !=""
-	// VLAN tag for the Talos nodes (rare).
-	vlan_tag?: string & !=""
+	default_gateway: net.IPv4 & !="" | *net.AddIP(strings.Split(node_cidr, "/")[0], 1)
+	// VLAN tag for the Talos nodes (rare). Must be 1-4094.
+	vlan_tag?: =~"^[0-9]+$"
+	if vlan_tag != _|_ {
+		_vlan_tag_in_range: >=1 & <=4094
+		_vlan_tag_in_range: strconv.Atoi(vlan_tag)
+	}
 }
 
 #Kubernetes: {
@@ -57,6 +77,8 @@ import (
 	pod_cidr: *"10.42.0.0/16" | net.IPCIDR
 	// The service CIDR for the cluster, /16 recommended.
 	svc_cidr: *"10.43.0.0/16" | net.IPCIDR
+	// CoreDNS service address, the 10th IP in svc_cidr.
+	coredns_addr: net.AddIP(strings.Split(svc_cidr, "/")[0], 10)
 	api: {
 		// The IP address of the Kube API.
 		addr: net.IPv4
@@ -116,10 +138,18 @@ _known_ssh_hosts: ["github.com", "gitlab.com", "codeberg.org"]
 	bgp: {
 		// The IP address of the BGP router.
 		router_addr: *"" | net.IPv4 & !=""
-		// The BGP router ASN.
-		router_asn: *"" | string & !=""
-		// The BGP node ASN.
-		node_asn: *"" | string & !=""
+		// The BGP router ASN (1-4294967295).
+		router_asn: *"" | =~"^[0-9]+$"
+		if router_asn != "" {
+			_router_asn_in_range: >=1 & <=4294967295
+			_router_asn_in_range: strconv.Atoi(router_asn)
+		}
+		// The BGP node ASN (1-4294967295).
+		node_asn: *"" | =~"^[0-9]+$"
+		if node_asn != "" {
+			_node_asn_in_range: >=1 & <=4294967295
+			_node_asn_in_range: strconv.Atoi(node_asn)
+		}
 	}
 }
 

--- a/template/scripts/plugin.py
+++ b/template/scripts/plugin.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import Any
 
 import base64
-import ipaddress
 import json
 import makejinja
 import re
@@ -12,17 +11,6 @@ import subprocess
 # Return the filename of a path without the j2 extension
 def basename(value: str) -> str:
     return Path(value).stem
-
-
-# Return the nth host in a CIDR range
-def nthhost(value: str, query: int) -> str:
-    try:
-        network = ipaddress.ip_network(value, strict=False)
-        if 0 <= query < network.num_addresses:
-            return str(network[query])
-    except ValueError:
-        pass
-    return False
 
 
 # Return the age public or private key from age.key
@@ -167,10 +155,6 @@ class Plugin(makejinja.plugin.Plugin):
 
     def data(self) -> makejinja.plugin.Data:
         data = cue_export()
-        # network.default_gateway is the one default CUE cannot express
-        # (no CIDR arithmetic in CUE's stdlib).
-        network = data['network']
-        network.setdefault('default_gateway', nthhost(network['node_cidr'], 1))
         # The deploy key secret always pins every bundled provider host key
         # (entries are matched per-hostname, so unused ones are inert);
         # user-supplied entries for self-hosted git servers are appended.
@@ -183,8 +167,7 @@ class Plugin(makejinja.plugin.Plugin):
 
     def filters(self) -> makejinja.plugin.Filters:
         return [
-            basename,
-            nthhost
+            basename
         ]
 
 


### PR DESCRIPTION
## Summary

The schema predates CUE's CIDR arithmetic (`net.InCIDR`, `net.AddIP`); using it closes several gaps where comments claimed constraints the schema never enforced.

### New validation

- **Real CIDR overlap detection**: the node/pod/svc checks were string equality only, so `node_cidr = "10.42.128.0/17"` nested inside the default pod CIDR passed. Containment checks via `net.InCIDR` catch nesting, and replace the pairwise `!=` workaround whose failure mode was the cryptic `ambiguous default elimination` error.
- **CIDR membership**: node addresses, `kubernetes.api.addr` and `network.default_gateway` must be inside `node_cidr` (previously only stated in comments). Gateway VIPs must too, but only when BGP is disabled, since BGP can legitimately announce out-of-subnet VIPs.
- **Cross-list collisions**: the API VIP, gateway VIPs and node addresses are now checked for uniqueness as one set; previously a node could silently reuse a gateway VIP.
- **Range checks**: `vlan_tag` must be numeric 1-4094; BGP ASNs must be numeric within the 32-bit ASN range.

### Computed values moved into CUE

`network.default_gateway` (first host of `node_cidr`) and the CoreDNS `clusterIP` (10th host of `svc_cidr`, now exported as `kubernetes.coredns_addr`) are computed in the schema via `net.AddIP`. This deletes the `nthhost` filter and the last data mutation in `plugin.py`, and keeps the templates free of address math.

### Tests

Five new invalid fixtures, one per new rejection class: `nested-cidr-overlap`, `node-addr-outside-cidr`, `gateway-node-collision`, `bad-vlan-tag`, `bad-bgp-asn`; all wired into the e2e matrix.

## Verification

- All 4 valid fixtures pass `cue export`; full `just configure` green for public (explicit gateway, VLAN, BGP) and private (exercises the CUE-computed `default_gateway`), with rendered output spot-checked: CoreDNS `clusterIP: 10.43.0.10", talconfig routes `gateway: 10.10.10.1`
- All 12 invalid fixtures rejected, each by its intended constraint; direct field errors (e.g. `nodes.0.mac_addr`) still surface with exact TOML line references
- The old `overlapping-cidrs` fixture now fails with a readable `_cidr_overlap_check.node_cidr_overlaps_pod_cidr` path instead of the ambiguous-default-elimination error

## Review follow-up (second commit)

A recall-focused multi-angle review of this branch found three correctness gaps in the first commit, all fixed here:

- **Non-canonical CIDRs silently derived wrong addresses**: `net.IPCIDR` accepts `10.10.10.5/24`, and the base-IP-plus-offset derivation then produced `default_gateway = 10.10.10.6` (the removed python `nthhost` normalized to `10.10.10.1`). The schema now rejects CIDRs with host bits set (`_cidr_canonical_check`, via the base-minus-one containment trick), so every derived address is computed from a true network base.
- **`coredns_addr` could fall outside `svc_cidr`** (e.g. a /29 has no 10th host): now guarded by `_coredns_addr_in_svc_cidr`.
- **A node could claim the default gateway IP**: `default_gateway` is now part of the uniqueness check (verified the defaulted disjunction resolves correctly inside `list.UniqueItems`).

Design fix: `coredns_addr` is now an overridable default (`net.IPv4 | *10th-of-svc_cidr`) instead of a fixed computed value a user could only conflict with; overrides are validated by the containment check.

Cleanup from the same review: doubled hidden-field constraints collapsed to single expressions, CIDR base extraction hoisted into `let` bindings, the ASN range check deduplicated into one comprehension covering both fields, and `list.Concat` replaced with a flat list literal - which also restores direct field errors (`nodes.0.mac_addr: ...`) instead of Concat-wrapped ones.

Three new invalid fixtures cover the new rejections: `non-canonical-cidr`, `tiny-svc-cidr`, `node-uses-gateway-addr` (15 invalid fixtures total in the matrix).
