### PR TITLE
feat(template): make cloudflare optional via dns and ingress modes

### DIFF
--- a/.github/tests/invalid/bad-bgp-asn.toml
+++ b/.github/tests/invalid/bad-bgp-asn.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [cilium.bgp]
 router_addr = "10.10.1.1"

--- a/.github/tests/invalid/bad-mac-address.toml
+++ b/.github/tests/invalid/bad-mac-address.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/bad-repo-url.toml
+++ b/.github/tests/invalid/bad-repo-url.toml
@@ -15,9 +15,11 @@ external = "10.10.10.251"
 [repository]
 url = "git@github.com:onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/bad-vlan-tag.toml
+++ b/.github/tests/invalid/bad-vlan-tag.toml
@@ -15,9 +15,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/duplicate-gateway-addrs.toml
+++ b/.github/tests/invalid/duplicate-gateway-addrs.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/duplicate-node-names.toml
+++ b/.github/tests/invalid/duplicate-node-names.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/gateway-node-collision.toml
+++ b/.github/tests/invalid/gateway-node-collision.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/missing-dns-token.toml
+++ b/.github/tests/invalid/missing-dns-token.toml
@@ -1,6 +1,5 @@
-# Negative fixture: a node claims the default gateway address (defaults to
-# the first IP in node_cidr).
-# Expected to be rejected by _addr_uniqueness_check.
+# Negative fixture: dns.provider "cloudflare" (the default) without a token.
+# Expected to be rejected by the Dns validator.
 [network]
 node_cidr = "10.10.10.0/24"
 
@@ -12,18 +11,18 @@ internal = "10.10.10.252"
 dns      = "10.10.10.253"
 external = "10.10.10.251"
 
-[repository]
-url = "https://github.com/onedr0p/cluster-template.git"
-
 [domain]
 name = "example.com"
 
 [dns]
-token = "fake"
+provider = "cloudflare"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
 
 [[nodes]]
 name         = "k8s-0"
-address      = "10.10.10.1"
+address      = "10.10.10.100"
 controller   = true
 disk         = "/dev/sdfake"
 mac_addr     = "00:00:00:00:00:00"

--- a/.github/tests/invalid/missing-external-gateway.toml
+++ b/.github/tests/invalid/missing-external-gateway.toml
@@ -1,6 +1,5 @@
-# Negative fixture: a node claims the default gateway address (defaults to
-# the first IP in node_cidr).
-# Expected to be rejected by _addr_uniqueness_check.
+# Negative fixture: cloudflare-tunnel ingress without gateways.external.
+# Expected to be rejected by the Config cross-check.
 [network]
 node_cidr = "10.10.10.0/24"
 
@@ -10,10 +9,6 @@ addr = "10.10.10.254"
 [gateways]
 internal = "10.10.10.252"
 dns      = "10.10.10.253"
-external = "10.10.10.251"
-
-[repository]
-url = "https://github.com/onedr0p/cluster-template.git"
 
 [domain]
 name = "example.com"
@@ -21,9 +16,12 @@ name = "example.com"
 [dns]
 token = "fake"
 
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
 [[nodes]]
 name         = "k8s-0"
-address      = "10.10.10.1"
+address      = "10.10.10.100"
 controller   = true
 disk         = "/dev/sdfake"
 mac_addr     = "00:00:00:00:00:00"

--- a/.github/tests/invalid/missing-known-hosts.toml
+++ b/.github/tests/invalid/missing-known-hosts.toml
@@ -15,9 +15,11 @@ external = "10.10.10.251"
 [repository]
 url = "ssh://git@git.example.com/k8s/home-ops.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/nested-cidr-overlap.toml
+++ b/.github/tests/invalid/nested-cidr-overlap.toml
@@ -15,9 +15,11 @@ external = "10.42.128.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/node-addr-outside-cidr.toml
+++ b/.github/tests/invalid/node-addr-outside-cidr.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/non-canonical-cidr.toml
+++ b/.github/tests/invalid/non-canonical-cidr.toml
@@ -15,9 +15,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/overlapping-cidrs.toml
+++ b/.github/tests/invalid/overlapping-cidrs.toml
@@ -14,9 +14,11 @@ external = "10.42.0.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/reserved-node-name.toml
+++ b/.github/tests/invalid/reserved-node-name.toml
@@ -14,9 +14,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "controller"

--- a/.github/tests/invalid/tiny-svc-cidr.toml
+++ b/.github/tests/invalid/tiny-svc-cidr.toml
@@ -18,9 +18,11 @@ external = "10.10.10.251"
 [repository]
 url = "https://github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/invalid/tunnel-without-dns.toml
+++ b/.github/tests/invalid/tunnel-without-dns.toml
@@ -1,6 +1,5 @@
-# Negative fixture: a node claims the default gateway address (defaults to
-# the first IP in node_cidr).
-# Expected to be rejected by _addr_uniqueness_check.
+# Negative fixture: cloudflare-tunnel ingress with dns.provider "none".
+# Expected to be rejected by the Config cross-check.
 [network]
 node_cidr = "10.10.10.0/24"
 
@@ -12,18 +11,21 @@ internal = "10.10.10.252"
 dns      = "10.10.10.253"
 external = "10.10.10.251"
 
-[repository]
-url = "https://github.com/onedr0p/cluster-template.git"
-
 [domain]
 name = "example.com"
 
 [dns]
-token = "fake"
+provider = "none"
+
+[ingress]
+mode = "cloudflare-tunnel"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
 
 [[nodes]]
 name         = "k8s-0"
-address      = "10.10.10.1"
+address      = "10.10.10.100"
 controller   = true
 disk         = "/dev/sdfake"
 mac_addr     = "00:00:00:00:00:00"

--- a/.github/tests/valid/direct.toml
+++ b/.github/tests/valid/direct.toml
@@ -1,0 +1,38 @@
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
+
+[ingress]
+mode = "direct"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
+[[nodes]]
+name         = "k8s-1"
+address      = "10.10.10.101"
+controller   = false
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:01"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/valid/internal.toml
+++ b/.github/tests/valid/internal.toml
@@ -7,20 +7,15 @@ addr = "10.10.10.254"
 [gateways]
 internal = "10.10.10.252"
 dns      = "10.10.10.253"
-external = "10.10.10.251"
-
-[repository]
-url              = "ssh://git@git.example.com/k8s/home-ops.git"
-webhook_provider = "generic-hmac"
-known_hosts      = """
-git.example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
-"""
 
 [domain]
 name = "example.com"
 
 [dns]
-token = "fake"
+provider = "none"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/valid/no-webhook.toml
+++ b/.github/tests/valid/no-webhook.toml
@@ -13,9 +13,11 @@ external = "10.10.10.251"
 url              = "https://github.com/onedr0p/cluster-template.git"
 webhook_provider = "none"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/valid/private.toml
+++ b/.github/tests/valid/private.toml
@@ -12,9 +12,11 @@ external = "10.10.10.251"
 [repository]
 url = "ssh://git@github.com/onedr0p/cluster-template.git"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [[nodes]]
 name         = "k8s-0"

--- a/.github/tests/valid/public.toml
+++ b/.github/tests/valid/public.toml
@@ -22,9 +22,11 @@ external = "10.10.10.251"
 url    = "https://github.com/onedr0p/cluster-template.git"
 branch = "main"
 
-[cloudflare]
-domain = "example.com"
-token  = "fake"
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
 
 [cilium]
 loadbalancer_mode = "dsr"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,6 +43,9 @@ jobs:
           - gateway-node-collision
           - bad-vlan-tag
           - bad-bgp-asn
+          - missing-dns-token
+          - tunnel-without-dns
+          - missing-external-gateway
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -79,6 +82,7 @@ jobs:
           - private
           - selfhosted
           - no-webhook
+          - internal
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -83,6 +83,7 @@ jobs:
           - selfhosted
           - no-webhook
           - internal
+          - direct
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ These guidelines provide a strong baseline, but there are always exceptions and 
     cloudflared tunnel create --credentials-file cloudflare-tunnel.json kubernetes
     ```
 
+    📍 _**Prefer port-forwarding over a tunnel?** Set `mode = "direct"` under `[ingress]` in `cluster.toml` and skip this step: no `cloudflare-tunnel.json` is needed. Instead, forward TCP 443 (and optionally 80) on your router to the `gateways.external` IP, and create an `external.<domain>` DNS record yourself pointing at your WAN address (an A record, or a CNAME to a DDNS hostname). Per-app records are still published automatically._
+
 ### Stage 5: Cluster configuration
 
 1. Generate the config files from the sample files:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ With this approach, you'll gain a solid foundation to build and manage your Kube
 
 A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/talos) and an opinionated implementation of [Flux](https://github.com/fluxcd/flux2) syncing from the Git provider of your choice (GitHub, GitLab, Gitea, Forgejo, Codeberg or self-hosted), [sops](https://github.com/getsops/sops) to manage secrets and [cloudflared](https://github.com/cloudflare/cloudflared) to access applications external to your local network.
 
-- **Required:** Some knowledge of [Containers](https://opencontainers.org/), [YAML](https://noyaml.com/), [Git](https://git-scm.com/), and a **Cloudflare account** with a **domain**.
+- **Required:** Some knowledge of [Containers](https://opencontainers.org/), [YAML](https://noyaml.com/), [Git](https://git-scm.com/), and a **domain**. Exposing apps to the public internet requires a **Cloudflare account**; internal-only clusters don't.
 - **Included components:** [flux](https://github.com/fluxcd/flux2), [cilium](https://github.com/cilium/cilium), [cert-manager](https://github.com/cert-manager/cert-manager), [spegel](https://github.com/spegel-org/spegel), [reloader](https://github.com/stakater/Reloader), [envoy-gateway](https://github.com/envoyproxy/gateway), [external-dns](https://github.com/kubernetes-sigs/external-dns) and [cloudflared](https://github.com/cloudflare/cloudflared).
 
 **Other features include:**
@@ -99,6 +99,9 @@ These guidelines provide a strong baseline, but there are always exceptions and 
     ```
 
 ### Stage 4: Cloudflare configuration
+
+> [!TIP]
+> **Internal-only cluster?** Set `provider = "none"` under `[dns]` in `cluster.toml` and skip this stage entirely: no Cloudflare account, API token, or `cloudflare-tunnel.json` is needed. Nothing is exposed to the internet, apps are reachable on your LAN via the internal gateway, and the wildcard certificate is issued by an in-cluster self-signed CA instead of Let's Encrypt.
 
 > [!WARNING]
 > If any of the commands fail with `command not found` or `unknown command` it means `mise` is either not installed, activated or it could be configured incorrectly.

--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -101,10 +101,11 @@ internal = ""
 # REQUIRED.
 dns = ""
 
-# IP for the `envoy-external` gateway — sits behind the cloudflared tunnel
-# and handles traffic exposed to the public internet. HTTPRoutes that
-# reference this gateway become reachable via your cloudflare domain.
-# REQUIRED.
+# IP for the `envoy-external` gateway — sits behind the ingress path (e.g.
+# the cloudflared tunnel) and handles traffic exposed to the public
+# internet. HTTPRoutes that reference this gateway become reachable via
+# your public domain.
+# REQUIRED unless ingress.mode is "none" (internal-only cluster).
 external = ""
 
 
@@ -156,22 +157,49 @@ url = ""
 
 
 # =============================================================================
-#    DNS authority and tunnel provider for any apps you want to expose to
-#    the public internet. external-dns publishes records here automatically;
-#    cert-manager uses the same token for ACME DNS-01 challenges.
+#    The domain your cluster's hostnames live under. Used for every rendered
+#    hostname (echo, flux-webhook, internal split DNS) and the wildcard
+#    certificate, regardless of DNS provider.
 # =============================================================================
-[cloudflare]
+[domain]
 
-# The Cloudflare-managed domain hosting your cluster's public hostnames.
-# Used by external-dns, cert-manager, and the cloudflared tunnel.
 # REQUIRED. Example: "example.com"
-domain = ""
+name = ""
 
-# API token (NOT the global API key) with `Zone - DNS - Edit` and
+
+# =============================================================================
+#    Public DNS authority and certificate issuance. With "cloudflare",
+#    external-dns publishes records automatically and cert-manager issues a
+#    Let's Encrypt wildcard via ACME DNS-01. With "none", nothing is
+#    published and the wildcard certificate is issued by an in-cluster
+#    self-signed CA instead (internal-only cluster).
+# =============================================================================
+[dns]
+
+# OPTIONAL. Default: "cloudflare". Allowed: "cloudflare" | "none"
+
+# provider = "cloudflare"
+
+# Cloudflare API token (NOT the global API key) with `Zone - DNS - Edit` and
 # `Account - Cloudflare Tunnel - Read` permissions, scoped to the zone
 # above. See the README for token creation steps.
-# REQUIRED.
+# REQUIRED when provider is "cloudflare"; must be empty otherwise.
 token = ""
+
+
+# =============================================================================
+#    How the public internet reaches the cluster's external gateway. With
+#    "cloudflare-tunnel", cloudflared connects outbound so no ports are
+#    forwarded (requires dns.provider = "cloudflare" and
+#    cloudflare-tunnel.json). With "none", nothing is exposed and apps are
+#    only reachable on your LAN via the internal gateway.
+# =============================================================================
+[ingress]
+
+# OPTIONAL. Default: "cloudflare-tunnel" when dns.provider is "cloudflare",
+# otherwise "none". Allowed: "cloudflare-tunnel" | "none"
+
+# mode = "cloudflare-tunnel"
 
 
 # =============================================================================

--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -191,13 +191,17 @@ token = ""
 #    How the public internet reaches the cluster's external gateway. With
 #    "cloudflare-tunnel", cloudflared connects outbound so no ports are
 #    forwarded (requires dns.provider = "cloudflare" and
-#    cloudflare-tunnel.json). With "none", nothing is exposed and apps are
-#    only reachable on your LAN via the internal gateway.
+#    cloudflare-tunnel.json). With "direct", you forward TCP 443 (and
+#    optionally 80) on your router to gateways.external and point an
+#    `external.<domain>` DNS record at your WAN address (A record or DDNS
+#    CNAME) yourself; per-app records are still published automatically.
+#    With "none", nothing is exposed and apps are only reachable on your
+#    LAN via the internal gateway.
 # =============================================================================
 [ingress]
 
 # OPTIONAL. Default: "cloudflare-tunnel" when dns.provider is "cloudflare",
-# otherwise "none". Allowed: "cloudflare-tunnel" | "none"
+# otherwise "none". Allowed: "cloudflare-tunnel" | "direct" | "none"
 
 # mode = "cloudflare-tunnel"
 

--- a/template/config/bootstrap/helmfile/crds.yaml.j2
+++ b/template/config/bootstrap/helmfile/crds.yaml.j2
@@ -19,11 +19,13 @@ bases:
   - default.yaml
 
 releases:
+  #% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
   - name: cloudflare-dns
     namespace: network
     inherit:
       - template: default
 
+  #% endif %#
   - name: envoy-gateway
     namespace: network
     inherit:

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' %#
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -17,3 +18,35 @@ spec:
               key: api-token
         selector:
           dnsZones: ["${SECRET_DOMAIN}"]
+#% else %#
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: internal-ca
+spec:
+  isCA: true
+  commonName: internal-ca
+  secretName: internal-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: internal-ca
+spec:
+  ca:
+    secretName: internal-ca
+#% endif %#

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/app/kustomization.yaml.j2
@@ -5,4 +5,6 @@ resources:
   - ./clusterissuer.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  #% if dns.provider == 'cloudflare' %#
   - ./secret.sops.yaml
+  #% endif %#

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' %#
 ---
 apiVersion: v1
 kind: Secret
@@ -5,3 +6,4 @@ metadata:
   name: cert-manager-secret
 stringData:
   api-token: "#{ cloudflare.token }#"
+#% endif %#

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/ks.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/ks.yaml.j2
@@ -11,7 +11,7 @@ spec:
       namespace: cert-manager
     - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer
-      name: letsencrypt-production
+      name: #{ cluster_issuer }#
   healthCheckExprs:
     - apiVersion: cert-manager.io/v1
       kind: ClusterIssuer

--- a/template/config/kubernetes/apps/default/echo/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/default/echo/app/helmrelease.yaml.j2
@@ -19,7 +19,7 @@ spec:
       hostnames:
         - "{{ .Release.Name }}.${SECRET_DOMAIN}"
       parentRefs:
-        - name: envoy-external
+        - name: envoy-#{ 'external' if ingress.mode != 'none' else 'internal' }#
           namespace: network
     monitoring:
       serviceMonitor:

--- a/template/config/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml.j2
+++ b/template/config/kubernetes/apps/flux-system/flux-instance/app/httproute.yaml.j2
@@ -7,7 +7,7 @@ metadata:
 spec:
   hostnames: ["flux-webhook.${SECRET_DOMAIN}"]
   parentRefs:
-    - name: envoy-external
+    - name: envoy-#{ 'external' if ingress.mode != 'none' else 'internal' }#
       namespace: network
       sectionName: https
   rules:

--- a/template/config/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -33,3 +34,4 @@ spec:
       enabled: true
     podAnnotations:
       secret.reloader.stakater.com/reload: *secret
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-dns/app/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/app/kustomization.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -5,3 +6,4 @@ resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/app/ocirepository.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -11,3 +12,4 @@ spec:
   ref:
     tag: 1.21.1
   url: oci://ghcr.io/home-operations/charts-mirror/external-dns
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
 ---
 apiVersion: v1
 kind: Secret
@@ -5,3 +6,4 @@ metadata:
   name: cloudflare-dns-secret
 stringData:
   api-token: "#{ cloudflare.token }#"
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-dns/ks.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/ks.yaml.j2
@@ -1,3 +1,4 @@
+#% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -17,3 +18,4 @@ spec:
     namespace: flux-system
   targetNamespace: network
   wait: true
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
@@ -8,3 +9,4 @@ spec:
     - dnsName: "external.${SECRET_DOMAIN}"
       recordType: CNAME
       targets: ["#{ cloudflare_tunnel_id() }#.cfargotunnel.com"]
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -82,3 +83,4 @@ spec:
         globalMounts:
           - path: /etc/cloudflared/config.yaml
             subPath: config.yaml
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -6,3 +7,4 @@ resources:
   - ./secret.sops.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/app/ocirepository.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -11,3 +12,4 @@ spec:
   ref:
     tag: 5.0.1
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/app/secret.sops.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/app/secret.sops.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: v1
 kind: Secret
@@ -5,3 +6,4 @@ metadata:
   name: cloudflare-tunnel-secret
 stringData:
   TUNNEL_TOKEN: "#{ cloudflare_tunnel_secret() }#"
+#% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-tunnel/ks.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-tunnel/ks.yaml.j2
@@ -1,3 +1,4 @@
+#% if ingress.mode == 'cloudflare-tunnel' %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
@@ -17,3 +18,4 @@ spec:
     namespace: flux-system
   targetNamespace: network
   wait: false
+#% endif %#

--- a/template/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
+++ b/template/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
@@ -9,7 +9,7 @@ spec:
     - "*.${SECRET_DOMAIN}"
   duration: 160h
   issuerRef:
-    name: letsencrypt-production
+    name: #{ cluster_issuer }#
     kind: ClusterIssuer
   privateKey:
     algorithm: ECDSA

--- a/template/config/kubernetes/apps/network/envoy-gateway/app/envoy.yaml.j2
+++ b/template/config/kubernetes/apps/network/envoy-gateway/app/envoy.yaml.j2
@@ -40,6 +40,7 @@ spec:
     kind: EnvoyProxy
     name: envoy
     namespace: network
+#% if ingress.mode != 'none' %#
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -70,6 +71,7 @@ spec:
         certificateRefs:
           - kind: Secret
             name: ${SECRET_DOMAIN/./-}-production-tls
+#% endif %#
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -156,9 +158,11 @@ metadata:
     external-dns.alpha.kubernetes.io/controller: none
 spec:
   parentRefs:
+    #% if ingress.mode != 'none' %#
     - name: envoy-external
       namespace: network
       sectionName: http
+    #% endif %#
     - name: envoy-internal
       namespace: network
       sectionName: http

--- a/template/config/kubernetes/apps/network/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/network/kustomization.yaml.j2
@@ -8,7 +8,11 @@ components:
 
 resources:
   - ./namespace.yaml
+  #% if dns.provider == 'cloudflare' and ingress.mode != 'none' %#
   - ./cloudflare-dns/ks.yaml
+  #% endif %#
+  #% if ingress.mode == 'cloudflare-tunnel' %#
   - ./cloudflare-tunnel/ks.yaml
+  #% endif %#
   - ./envoy-gateway/ks.yaml
   - ./k8s-gateway/ks.yaml

--- a/template/config/kubernetes/components/sops/cluster-secrets.sops.yaml.j2
+++ b/template/config/kubernetes/components/sops/cluster-secrets.sops.yaml.j2
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: cluster-secrets
 stringData:
-  SECRET_DOMAIN: "#{ cloudflare.domain }#"
+  SECRET_DOMAIN: "#{ domain.name }#"

--- a/template/mod.just
+++ b/template/mod.just
@@ -33,7 +33,10 @@ doctor:
     just log info "just version" version "{{ just_version() }}"
     just template doctor-check "cluster.toml"           "{{ config_file }}"           || rc=1
     just template doctor-check "cluster.sample.toml"    "{{ sample_config_file }}"    || rc=1
-    just template doctor-check "cloudflare-tunnel.json" "{{ cloudflare_tunnel }}"     || rc=1
+    mode="$(uv run --quiet "{{ validate_script }}" "{{ config_file }}" 2>/dev/null | jq -r '.ingress.mode' || true)"
+    if [ "$mode" = "cloudflare-tunnel" ]; then
+        just template doctor-check "cloudflare-tunnel.json" "{{ cloudflare_tunnel }}" || rc=1
+    fi
     just template doctor-check "age.key"                "$SOPS_AGE_KEY_FILE"          || rc=1
     just template doctor-check "deploy.key"             "{{ deploy_key }}"            || rc=1
     just template doctor-check "flux-webhook-token.txt" "{{ webhook_token_file }}"    || rc=1
@@ -71,9 +74,16 @@ reset:
 [group('template')]
 tidy: tidy-preconditions tidy-strip tidy-archive
 
+# cloudflare-tunnel.json is only needed when the config uses the tunnel; an
+# unparseable config falls through so render can surface validation errors.
 [private]
+[script]
 configure-preconditions:
-    test -f "{{ cloudflare_tunnel }}" || { just log error "cloudflare-tunnel.json not found — see README"; exit 1; }
+    mode="$(uv run --quiet "{{ validate_script }}" "{{ config_file }}" 2>/dev/null | jq -r '.ingress.mode' || true)"
+    if [ "$mode" = "cloudflare-tunnel" ] && [ ! -f "{{ cloudflare_tunnel }}" ]; then
+        just log error "cloudflare-tunnel.json not found — see README"
+        exit 1
+    fi
 
 [no-exit-message]
 [private]

--- a/template/scripts/test_validate.py
+++ b/template/scripts/test_validate.py
@@ -97,6 +97,21 @@ def test_derived_fields_are_not_settable():
         _load_raw(raw)
 
 
+def test_ingress_mode_follows_dns_provider():
+    cloudflare = config_from("public.toml", ingress=None)
+    assert _load_raw(cloudflare).ingress.mode == "cloudflare-tunnel"
+    internal = config_from("internal.toml")
+    assert (REPO_ROOT / ".github/tests/valid/internal.toml").exists()
+    assert "ingress" not in internal
+    assert _load_raw(internal).ingress.mode == "none"
+
+
+def test_direct_mode_requires_cloudflare_dns():
+    raw = config_from("internal.toml", **{"ingress.mode": "direct"})
+    with pytest.raises(ConfigError, match="requires dns.provider 'cloudflare'"):
+        _load_raw(raw)
+
+
 def test_gateways_may_leave_node_cidr_only_with_bgp():
     with_bgp = config_from("public.toml", **{"gateways.external": "192.168.50.1"})
     _load_raw(with_bgp)  # public.toml enables BGP

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -161,7 +161,7 @@ class Dns(Model):
 
 
 class Ingress(Model):
-    mode: Literal["cloudflare-tunnel", "none"] = "cloudflare-tunnel"
+    mode: Literal["cloudflare-tunnel", "direct", "none"] = "cloudflare-tunnel"
 
 
 class Bgp(Model):
@@ -228,9 +228,9 @@ class Config(Model):
 
     @model_validator(mode="after")
     def check(self) -> Self:
-        if self.ingress.mode == "cloudflare-tunnel" and self.dns.provider != "cloudflare":
+        if self.ingress.mode != "none" and self.dns.provider != "cloudflare":
             raise ValueError(
-                "ingress.mode 'cloudflare-tunnel' requires dns.provider 'cloudflare'"
+                f"ingress.mode {self.ingress.mode!r} requires dns.provider 'cloudflare'"
             )
         if self.ingress.mode != "none" and self.gateways.external is None:
             raise ValueError(

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -121,7 +121,8 @@ class Kubernetes(Model):
 class Gateways(Model):
     internal: IPv4Address
     dns: IPv4Address
-    external: IPv4Address
+    # Required when ingress.mode is not "none".
+    external: IPv4Address | None = None
 
 
 class Repository(Model):
@@ -142,9 +143,25 @@ class Repository(Model):
         return self
 
 
-class Cloudflare(Model):
-    domain: Fqdn
-    token: str
+class Domain(Model):
+    name: Fqdn
+
+
+class Dns(Model):
+    provider: Literal["cloudflare", "none"] = "cloudflare"
+    token: str = ""
+
+    @model_validator(mode="after")
+    def check(self) -> Self:
+        if self.provider == "cloudflare" and not self.token:
+            raise ValueError("token is required when dns.provider is 'cloudflare'")
+        if self.provider == "none" and self.token:
+            raise ValueError("token must be empty when dns.provider is 'none'")
+        return self
+
+
+class Ingress(Model):
+    mode: Literal["cloudflare-tunnel", "none"] = "cloudflare-tunnel"
 
 
 class Bgp(Model):
@@ -182,7 +199,15 @@ class Config(Model):
     kubernetes: Kubernetes
     gateways: Gateways
     repository: Repository
-    cloudflare: Cloudflare
+    domain: Domain
+    dns: Dns
+    # Defaults to "cloudflare-tunnel" when dns.provider is "cloudflare",
+    # otherwise "none".
+    ingress: Ingress = Field(
+        default_factory=lambda data: Ingress(
+            mode="cloudflare-tunnel" if data["dns"].provider == "cloudflare" else "none"
+        )
+    )
     cilium: Cilium = Cilium()
     nodes: list[Node]
     # True when there is more than one node, unless set explicitly.
@@ -194,8 +219,24 @@ class Config(Model):
         bgp = self.cilium.bgp
         return bgp.router_addr != "" and bgp.router_asn != "" and bgp.node_asn != ""
 
+    @computed_field
+    @property
+    def cluster_issuer(self) -> str:
+        if self.dns.provider == "cloudflare":
+            return "letsencrypt-production"
+        return "internal-ca"
+
     @model_validator(mode="after")
     def check(self) -> Self:
+        if self.ingress.mode == "cloudflare-tunnel" and self.dns.provider != "cloudflare":
+            raise ValueError(
+                "ingress.mode 'cloudflare-tunnel' requires dns.provider 'cloudflare'"
+            )
+        if self.ingress.mode != "none" and self.gateways.external is None:
+            raise ValueError(
+                f"gateways.external is required when ingress.mode is {self.ingress.mode!r}"
+            )
+
         cidrs = {
             "network.node_cidr": self.network.node_cidr,
             "kubernetes.pod_cidr": self.kubernetes.pod_cidr,
@@ -211,9 +252,10 @@ class Config(Model):
             "kubernetes.api.addr": self.kubernetes.api.addr,
             "gateways.internal": self.gateways.internal,
             "gateways.dns": self.gateways.dns,
-            "gateways.external": self.gateways.external,
             "network.default_gateway": self.network.default_gateway,
         } | {f"nodes[{i}].address": n.address for i, n in enumerate(self.nodes)}
+        if self.gateways.external is not None:
+            addresses["gateways.external"] = self.gateways.external
         seen: dict[IPv4Address, str] = {}
         for owner, addr in addresses.items():
             if addr in seen:
@@ -235,7 +277,7 @@ class Config(Model):
         if not self.cilium_bgp_enabled:
             for name in ("internal", "dns", "external"):
                 addr = getattr(self.gateways, name)
-                if addr not in node_cidr:
+                if addr is not None and addr not in node_cidr:
                     raise ValueError(
                         f"gateways.{name} {addr} is not inside node_cidr {node_cidr} "
                         "(required unless BGP is enabled)"


### PR DESCRIPTION
## Summary

Stages 1 and 2 of decoupling the template from Cloudflare: split the monolithic `[cloudflare]` config into the three roles it actually plays, add a fully supported **internal-only mode** that needs no Cloudflare account at all, and a **direct ingress mode** that keeps Cloudflare DNS but drops the tunnel.

### New config surface

```toml
[domain]
name = "example.com"        # the domain, independent of any provider

[dns]                         # public DNS authority + certificate issuance
provider = "cloudflare"      # "cloudflare" | "none"   (default: cloudflare)
token    = "..."             # required iff provider = cloudflare

[ingress]                     # how the internet reaches envoy-external
mode = "cloudflare-tunnel"   # "cloudflare-tunnel" | "direct" | "none"
                              # defaults to none when dns.provider is none
```

Cross-rules enforced by the validator: any enabled ingress mode requires `dns.provider = "cloudflare"`; `gateways.external` is only required when ingress is enabled; a token with `provider = "none"` is rejected.

### Internal-only mode (`dns.provider = "none"`)

- `cloudflare-dns` and `cloudflare-tunnel` apps are not rendered at all (dirs absent, helmfile CRD extraction adjusted), and `envoy-external` is not created
- echo and the flux-webhook HTTPRoutes attach to `envoy-internal` instead
- the wildcard certificate is issued by an in-cluster self-signed CA (`selfsigned` → CA cert → `internal-ca` ClusterIssuer) so gateway TLS keeps working with the same secret name; the Flux healthCheck follows via a computed `cluster_issuer`
- `cloudflare-tunnel.json` is no longer a hard precondition: `configure` and `doctor` only require it when `ingress.mode = "cloudflare-tunnel"`
- split DNS via k8s-gateway is unchanged, and this pairs naturally with `webhook_provider = "none"`

Existing Cloudflare users migrate mechanically: `cloudflare.domain` → `domain.name`, `cloudflare.token` → `dns.token`; everything else defaults to today's behavior (verified: the public-fixture render is unchanged).

### Direct mode (`ingress.mode = "direct"`)

Port-forwarding instead of a tunnel: the `cloudflare-tunnel` app is not rendered and `cloudflare-tunnel.json` is not required, while `cloudflare-dns`, the external gateway, and the Let's Encrypt issuer all stay. The user forwards TCP 443 to `gateways.external` and manages the `external.<domain>` record themselves (A record or DDNS CNAME); per-app records are still published automatically. Because the conditions are role-shaped, this mode needed no template changes at all — only the enum, the cross-rule, docs, and a fixture.

### Deliberate scope

Cloudflare remains the only in-tree DNS provider; additional providers slot into the same role seams later if wanted.

### Tests

- New valid fixtures `internal` and `direct` (both render end-to-end with no tunnel file present)
- New invalid fixtures `missing-dns-token`, `tunnel-without-dns`, `missing-external-gateway`
- All existing fixtures migrated to the new sections; pytest suite now 33 tests

## Verification

- 6/6 valid fixtures accepted, 18/18 invalid rejected, each by its intended rule
- Full `just configure` for public (Cloudflare mode: cloudflare apps, letsencrypt issuer, external gateway — all unchanged) internal (apps absent, self-signed CA chain, everything on `envoy-internal`), and direct (cloudflare-dns present, tunnel absent, external gateway + Let's Encrypt intact) — the latter two with `cloudflare-tunnel.json` deleted
- `just template doctor` skips the tunnel-file check in internal mode; `just --dry-run bootstrap apps` green; zizmor clean
