### PR TITLE
feat(template)!: move the spegel toggle into a spegel section

### DIFF
--- a/template/config/bootstrap/helmfile/apps.yaml.j2
+++ b/template/config/bootstrap/helmfile/apps.yaml.j2
@@ -29,7 +29,7 @@ releases:
       - template: default
     needs: ['kube-system/cilium']
 
-  #% if spegel_enabled %#
+  #% if spegel.enabled %#
   - name: spegel
     namespace: kube-system
     inherit:
@@ -41,7 +41,7 @@ releases:
     namespace: cert-manager
     inherit:
       - template: default
-    #% if spegel_enabled %#
+    #% if spegel.enabled %#
     needs: ['kube-system/spegel']
     #% else %#
     needs: ['kube-system/coredns']

--- a/template/config/kubernetes/apps/kube-system/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/kustomization.yaml.j2
@@ -12,6 +12,6 @@ resources:
   - ./coredns/ks.yaml
   - ./metrics-server/ks.yaml
   - ./reloader/ks.yaml
-  #% if spegel_enabled %#
+  #% if spegel.enabled %#
   - ./spegel/ks.yaml
   #% endif %#

--- a/template/config/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml.j2
@@ -1,4 +1,4 @@
-#% if spegel_enabled %#
+#% if spegel.enabled %#
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/template/config/kubernetes/apps/kube-system/spegel/app/kustomization.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/spegel/app/kustomization.yaml.j2
@@ -1,4 +1,4 @@
-#% if spegel_enabled %#
+#% if spegel.enabled %#
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/template/config/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml.j2
@@ -1,4 +1,4 @@
-#% if spegel_enabled %#
+#% if spegel.enabled %#
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository

--- a/template/config/kubernetes/apps/kube-system/spegel/ks.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/spegel/ks.yaml.j2
@@ -1,4 +1,4 @@
-#% if spegel_enabled %#
+#% if spegel.enabled %#
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/template/scripts/test_validate.py
+++ b/template/scripts/test_validate.py
@@ -85,10 +85,14 @@ def test_coredns_addr_default_and_override():
 
 def test_spegel_enabled_follows_node_count():
     two_nodes = config_from("private.toml")
-    assert _load_raw(two_nodes).spegel_enabled is True
+    assert _load_raw(two_nodes).spegel.enabled is True
     one_node = config_from("private.toml")
     one_node["nodes"] = one_node["nodes"][:1]
-    assert _load_raw(one_node).spegel_enabled is False
+    assert _load_raw(one_node).spegel.enabled is False
+    empty_section = config_from("private.toml", spegel={})
+    assert _load_raw(empty_section).spegel.enabled is True
+    explicit = config_from("private.toml", **{"spegel.enabled": False})
+    assert _load_raw(explicit).spegel.enabled is False
 
 
 def test_derived_fields_are_not_settable():

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -166,6 +166,11 @@ class Bgp(Model):
     node_asn: Asn = ""
 
 
+class Spegel(Model):
+    # True when the cluster has more than one node, unless set explicitly.
+    enabled: bool | None = None
+
+
 class Cilium(Model):
     loadbalancer_mode: Literal["dsr", "snat"] = "dsr"
     bgp: Bgp = Bgp()
@@ -205,9 +210,8 @@ class Config(Model):
         )
     )
     cilium: Cilium = Cilium()
+    spegel: Spegel = Spegel()
     nodes: list[Node]
-    # True when there is more than one node, unless set explicitly.
-    spegel_enabled: bool = Field(default_factory=lambda data: len(data["nodes"]) > 1)
 
     @computed_field
     @property
@@ -231,6 +235,8 @@ class Config(Model):
 
     @model_validator(mode="after")
     def check(self) -> Self:
+        if self.spegel.enabled is None:
+            self.spegel.enabled = len(self.nodes) > 1
         if self.ingress.mode != "none" and self.dns.provider != "cloudflare":
             raise ValueError(
                 f"ingress.mode {self.ingress.mode!r} requires dns.provider 'cloudflare'"


### PR DESCRIPTION
## Summary

`spegel_enabled` kept its node-count-derived default but had two real problems: it was **undocumented** (no mention in `cluster.sample.toml` or the README), and as a bare top-level key **TOML only allows it before the first table** - a user who discovered it and appended `spegel_enabled = false` to their config was actually setting `nodes[-1].spegel_enabled` and got a confusing validation error.

### Changes

- `[spegel] enabled` section with the same derived default (true when the cluster has more than one node, since spegel is a peer-to-peer mirror that needs peers), resolved in the validator when the key or section is omitted
- Documented in `cluster.sample.toml` with the derivation explained
- Mechanical rename across the six consuming templates (`spegel_enabled` → `spegel.enabled`)
- Test coverage for all four states: derived-true (2 nodes), derived-false (1 node), empty `[spegel]` section, and explicit `enabled = false`

Breaking only for anyone who had set the undocumented top-level key.

## Verification

- 34 pytest tests green (spegel test extended to the empty-section and explicit-override cases)
- Full `just configure`: spegel rendered with 2 nodes; with `enabled = false` a clean render omits the spegel app dir, its kustomization entry, and the helmfile release