### PR TITLE
feat(template): cluster-wide schematic default, schema-owned node defaults, bgp all-or-nothing

### DIFF
--- a/.github/tests/invalid/missing-schematic.toml
+++ b/.github/tests/invalid/missing-schematic.toml
@@ -1,0 +1,28 @@
+# Negative fixture: a node without schematic_id and no [talos] default.
+# Expected to be rejected by the schematic resolution in Config.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[[nodes]]
+name       = "k8s-0"
+address    = "10.10.10.100"
+controller = true
+disk       = "/dev/sdfake"
+mac_addr   = "00:00:00:00:00:00"

--- a/.github/tests/invalid/partial-bgp.toml
+++ b/.github/tests/invalid/partial-bgp.toml
@@ -1,0 +1,34 @@
+# Negative fixture: two of the three BGP fields set; previously this
+# silently left BGP disabled.
+# Expected to be rejected by the Bgp all-or-nothing check.
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+external = "10.10.10.251"
+
+[domain]
+name = "example.com"
+
+[dns]
+token = "fake"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[cilium.bgp]
+router_addr = "10.10.1.1"
+router_asn  = "64513"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/tests/valid/public.toml
+++ b/.github/tests/valid/public.toml
@@ -36,13 +36,15 @@ router_addr = "10.10.1.1"
 router_asn  = "64513"
 node_asn    = "64514"
 
+[talos]
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
 [[nodes]]
 name         = "k8s-0"
 address      = "10.10.10.100"
 controller   = true
 disk         = "/dev/sdfake"
 mac_addr     = "00:00:00:00:00:00"
-schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
 
 [[nodes]]
 name           = "k8s-1"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,6 +46,8 @@ jobs:
           - missing-dns-token
           - tunnel-without-dns
           - missing-external-gateway
+          - missing-schematic
+          - partial-bgp
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -247,6 +247,17 @@ token = ""
 
 
 # =============================================================================
+#    Talos Image Factory settings shared by all nodes.
+# =============================================================================
+[talos]
+
+# Default schematic for every node that doesn't set its own schematic_id.
+# The 64-character hex string from your build at https://factory.talos.dev/
+# OPTIONAL if every node sets schematic_id itself.
+schematic_id = ""
+
+
+# =============================================================================
 #    One [[nodes]] table per physical machine or VM in the cluster. At least
 #    one controller (controller=true) is required; worker nodes are optional.
 #    For HA, use 3 controllers.
@@ -268,6 +279,8 @@ token = ""
 # controller   = true           # true = control-plane (etcd + API server), false = worker.
 # disk         = "/dev/nvme0n1" # Block device or /dev/disk/by-id/... symlink to install Talos onto.
 # mac_addr     = "aa:bb:cc:dd:ee:ff"  # Primary NIC MAC.
+#
+# # Optional when [talos] sets a cluster-wide default:
 # schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"  # 64-hex from factory.talos.dev.
 #
 # # Optional advanced fields (each independently uncommentable):

--- a/template/config/talos/topf.yaml.j2
+++ b/template/config/talos/topf.yaml.j2
@@ -15,7 +15,7 @@ nodes:
     ip: "#{ item.address }#"
     role: #{ 'control-plane' if item.controller else 'worker' }#
     schematicId: "#{ item.schematic_id }#"
-    #% if item.secureboot | default(false, true) %#
+    #% if item.secureboot %#
     secureboot: true
     #% endif %#
     data:
@@ -27,7 +27,7 @@ nodes:
       installDiskSerial: "#{ item.disk }#"
       #% endif %#
       macAddr: "#{ item.mac_addr | lower }#"
-      mtu: #{ item.mtu | default(1500, true) }#
-      encryptDisk: #{ (item.encrypt_disk | default(false, true)) | string | lower }#
-      kernelModules: [#{ item.kernel_modules | default([], true) | join(', ') }#]
+      mtu: #{ item.mtu }#
+      encryptDisk: #{ item.encrypt_disk | string | lower }#
+      kernelModules: [#{ item.kernel_modules | join(', ') }#]
   #% endfor %#

--- a/template/scripts/test_validate.py
+++ b/template/scripts/test_validate.py
@@ -123,6 +123,27 @@ def test_direct_mode_requires_cloudflare_dns():
         _load_raw(raw)
 
 
+def test_schematic_id_inherits_from_talos_section():
+    raw = config_from("public.toml")
+    cfg = _load_raw(raw)
+    assert cfg.nodes[0].schematic_id == cfg.talos.schematic_id
+    assert cfg.nodes[1].schematic_id is not None
+
+
+def test_partial_bgp_rejected():
+    raw = config_from("private.toml", **{"cilium.bgp.router_addr": "10.10.1.1", "cilium.bgp.router_asn": "64513"})
+    with pytest.raises(ConfigError, match="partially configured"):
+        _load_raw(raw)
+
+
+def test_node_defaults_exported():
+    data = _load_raw(config_from("private.toml")).model_dump(mode="json")
+    node = data["nodes"][0]
+    assert node["mtu"] == 1500
+    assert node["secureboot"] is False
+    assert node["kernel_modules"] == []
+
+
 def test_gateways_may_leave_node_cidr_only_with_bgp():
     with_bgp = config_from("public.toml", **{"gateways.external": "192.168.50.1"})
     _load_raw(with_bgp)  # public.toml enables BGP

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -165,6 +165,21 @@ class Bgp(Model):
     router_asn: Asn = ""
     node_asn: Asn = ""
 
+    @model_validator(mode="after")
+    def check(self) -> Self:
+        unset = [name for name in ("router_addr", "router_asn", "node_asn") if getattr(self, name) == ""]
+        if unset and len(unset) < 3:
+            raise ValueError(
+                "bgp is partially configured: set router_addr, router_asn and "
+                f"node_asn together (missing: {', '.join(unset)})"
+            )
+        return self
+
+
+class Talos(Model):
+    # Default Image Factory schematic for nodes that don't set their own.
+    schematic_id: str | None = Field(default=None, pattern=r"^[a-z0-9]{64}$")
+
 
 class Spegel(Model):
     # True when the cluster has more than one node, unless set explicitly.
@@ -182,11 +197,12 @@ class Node(Model):
     controller: bool
     disk: str
     mac_addr: str = Field(pattern=r"^([0-9a-f]{2}:){5}[0-9a-f]{2}$")
-    schematic_id: str = Field(pattern=r"^[a-z0-9]{64}$")
-    mtu: int | None = Field(default=None, ge=1450, le=9000)
-    secureboot: bool | None = None
-    encrypt_disk: bool | None = None
-    kernel_modules: list[str] | None = None
+    # Falls back to talos.schematic_id when unset.
+    schematic_id: str | None = Field(default=None, pattern=r"^[a-z0-9]{64}$")
+    mtu: int = Field(default=1500, ge=1450, le=9000)
+    secureboot: bool = False
+    encrypt_disk: bool = False
+    kernel_modules: list[str] = []
 
     @model_validator(mode="after")
     def check(self) -> Self:
@@ -210,6 +226,7 @@ class Config(Model):
         )
     )
     cilium: Cilium = Cilium()
+    talos: Talos = Talos()
     spegel: Spegel = Spegel()
     nodes: list[Node]
 
@@ -237,6 +254,14 @@ class Config(Model):
     def check(self) -> Self:
         if self.spegel.enabled is None:
             self.spegel.enabled = len(self.nodes) > 1
+        for i, node in enumerate(self.nodes):
+            if node.schematic_id is None:
+                node.schematic_id = self.talos.schematic_id
+            if node.schematic_id is None:
+                raise ValueError(
+                    f"nodes[{i}].schematic_id is required: set it on the node "
+                    "or set a cluster-wide default in [talos]"
+                )
         if self.ingress.mode != "none" and self.dns.provider != "cloudflare":
             raise ValueError(
                 f"ingress.mode {self.ingress.mode!r} requires dns.provider 'cloudflare'"


### PR DESCRIPTION
## Summary

Three config-surface improvements from the section/derived-defaults audit:

### `[talos] schematic_id` - cluster-wide default

Nodes inherit the Image Factory schematic from a new `[talos]` section unless they set their own, removing the most copy-pasted line in real configs (fixtures repeated the identical 64-char hash on every node). A node with neither gets a clear error: `nodes[0].schematic_id is required: set it on the node or set a cluster-wide default in [talos]`. Documented in the sample; the public fixture exercises inheritance on one node and per-node override on the other.

### Node defaults move into the schema

`mtu` (1500), `secureboot`/`encrypt_disk` (false) and `kernel_modules` (`[]`) were defaulted via jinja `| default(...)` filters inside `topf.yaml.j2` - invisible to the exported config and inconsistent with the schema-owns-defaults philosophy everywhere else. They're now pydantic defaults; the template loses four filter expressions and `validate.py` is the single source for every default.

### `cilium.bgp` all-or-nothing

Setting one or two of `router_addr`/`router_asn`/`node_asn` previously left BGP **silently disabled** (`cilium_bgp_enabled` requires all three) - and with it silently changed the gateways-in-node-cidr exemption. Partial configuration now fails with the missing fields named: `bgp is partially configured: set router_addr, router_asn and node_asn together (missing: node_asn)`.

## Verification

- 6/6 valid and 20/20 invalid fixtures behave correctly (two new negative fixtures: `missing-schematic`, `partial-bgp`, both in the CI matrix)
- Rendered output proven **byte-identical** to a pre-change baseline for both fixture modes - `topf.yaml` and the topf-rendered machine configs - so the defaults relocation and schematic inheritance are render-neutral
- 39 pytest tests green (new: inheritance/override, partial-bgp rejection, exported node defaults); zizmor clean