### PR TITLE
fix(ci): specify repository when creating releases

### DIFF
--- a/.github/workflows/template-release.yaml
+++ b/.github/workflows/template-release.yaml
@@ -55,4 +55,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.determine-next-tag.outputs.result }}
-        run: gh release create "$TAG" --generate-notes
+        run: gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --generate-notes


### PR DESCRIPTION
## What

Pass the repository explicitly to `gh release create`.

The release job does not check out the repository, and current versions of `gh` do not infer `GH_REPO` from `GITHUB_REPOSITORY`. As a result, manual and scheduled runs fail while trying to discover a local Git repository.

## Error

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Failed run: https://github.com/onedr0p/cluster-template/actions/runs/29829994420

## Verification

- Workflow YAML parses successfully.
- Zizmor reports no findings.
- `git diff --check` passes.