### PR TITLE
refactor(sops): simplify and verify secret processing

### DIFF
--- a/.github/workflows/template-e2e-cluster.yaml
+++ b/.github/workflows/template-e2e-cluster.yaml
@@ -6,9 +6,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: ["main"]
-    paths:
-      - ".github/template-tests/e2e/**"
-      - ".github/workflows/template-e2e-cluster.yaml"
   schedule:
     - cron: "30 5 * * *"
 

--- a/template/config/bootstrap/mod.just
+++ b/template/config/bootstrap/mod.just
@@ -81,8 +81,8 @@ apps-secrets:
         "{{ kubernetes_dir }}/components/sops/cluster-secrets.sops.yaml"
     do
         name="$(basename "$secret" .sops.yaml)"
-        if sops exec-file "$secret" \
-                "kubectl --namespace flux-system apply --server-side --filename {}" &>/dev/null; then
+        if sops decrypt "$secret" \
+                | kubectl --namespace flux-system apply --server-side --filename - &>/dev/null; then
             just log info "Secret applied" resource "$name"
         else
             just log fatal "Failed to apply secret" resource "$name"

--- a/template/mod.just
+++ b/template/mod.just
@@ -101,7 +101,7 @@ encrypt-secrets:
                 just log fatal "could not read encryption status" file "$f"
             fi
             case "$status" in
-                false) sops --encrypt --in-place "$f" ;;
+                false) sops encrypt --in-place "$f" ;;
                 true)  : ;;
                 *)     just log fatal "could not determine encryption status" file "$f" ;;
             esac

--- a/template/mod.just
+++ b/template/mod.just
@@ -164,3 +164,6 @@ validate-kubernetes:
 [working-directory('talos')]
 validate-talos:
     topf render --confirm=false --output "$(mktemp -d)" >/dev/null
+    if ! sops filestatus secrets.sops.yaml | jq --exit-status '.encrypted == true' >/dev/null; then
+        just log fatal "Talos secrets bundle is not encrypted"
+    fi


### PR DESCRIPTION
## Summary

- pipe decrypted secrets directly into `kubectl` instead of using `sops exec-file`
- use the current `sops encrypt` subcommand form
- fail configuration if topf leaves its Talos secrets bundle unencrypted
- run the full E2E Cluster workflow on every pull request targeting `main`

## Validation

- justfile formatting and parsing
- workflow formatting
- `zizmor --offline`
- `git diff --check`