### PR TITLE
fix(renovate): group Talos updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -8,6 +8,12 @@
   },
   packageRules: [
     {
+      description: "Talos Group",
+      groupName: "talos",
+      matchPackageNames: ["ghcr.io/siderolabs/installer", "siderolabs/talos", "talosctl"],
+      minimumGroupSize: 3,
+    },
+    {
       description: "Flux Operator Group",
       groupName: "flux-operator",
       matchDatasources: ["docker"],


### PR DESCRIPTION
## Summary

- group Talos CLI, installer image, and topf Talos version updates
- require all three dependencies to have updates before Renovate creates the grouped PR

## Validation

- `oxfmt --check .renovaterc.json5`
- `renovate-config-validator .renovaterc.json5`

Closes #438