### PR TITLE
fix(template): populate cloudflare api token from dns.token

### DIFF
--- a/cluster.sample.toml
+++ b/cluster.sample.toml
@@ -96,7 +96,7 @@ addr = ""
 internal = ""
 
 # IP for `k8s_gateway`, which serves DNS for cluster-managed hostnames.
-# Point your home DNS server's conditional forwarder for cloudflare.domain
+# Point your home DNS server's conditional forwarder for domain.name
 # at this IP to enable split-DNS resolution from your LAN.
 # REQUIRED.
 dns = ""

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml.j2
@@ -5,5 +5,5 @@ kind: Secret
 metadata:
   name: cert-manager-secret
 stringData:
-  api-token: "#{ cloudflare.token }#"
+  api-token: "#{ dns.token }#"
 #% endif %#

--- a/template/config/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml.j2
+++ b/template/config/kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml.j2
@@ -5,5 +5,5 @@ kind: Secret
 metadata:
   name: cloudflare-dns-secret
 stringData:
-  api-token: "#{ cloudflare.token }#"
+  api-token: "#{ dns.token }#"
 #% endif %#


### PR DESCRIPTION
## Problem

After #2292, a fresh render leaves the Cloudflare API token empty in both secrets that consume it:

```console
$ sops -d kubernetes/apps/cert-manager/cert-manager/app/secret.sops.yaml | yq '.stringData.api-token'

$ sops -d kubernetes/apps/network/cloudflare-dns/app/secret.sops.yaml | yq '.stringData.api-token'

```

## Cause

#2292 split `[cloudflare]` into `[domain]` / `[dns]` / `[ingress]`, moving the token to `dns.token`. The two secret templates were missed and still interpolate `#{ cloudflare.token }#`.

This failed silently rather than loudly because `makejinja.toml` sets `undefined = "chainable"`: an attribute lookup on the now-nonexistent `cloudflare` resolves to another undefined and renders as an empty string. So `just configure` succeeded, kubeconform passed, and SOPS happily encrypted an empty `api-token` — the breakage only appears at decrypt time, or at runtime when cert-manager and external-dns fail to authenticate.

## Changes

- `cert-manager/app/secret.sops.yaml.j2`: `cloudflare.token` → `dns.token`
- `cloudflare-dns/app/secret.sops.yaml.j2`: same
- `cluster.sample.toml`: stale `cloudflare.domain` reference in a comment → `domain.name`

I swept the tree for other survivors of the rename — `cloudflare` was the only stale variable root, and it appeared only in those two templates. `cloudflare_tunnel_id` / `cloudflare_tunnel_secret` are plugin functions, not config, so they are unaffected.

## Verification

Full `just configure` against all six valid fixtures, with a clean render each time:

```
public       cert-manager=[fake]   cloudflare-dns=[fake]
private      cert-manager=[fake]   cloudflare-dns=[fake]
selfhosted   cert-manager=[fake]   cloudflare-dns=[fake]
no-webhook   cert-manager=[fake]   cloudflare-dns=[fake]
internal     cert-manager=ABSENT   cloudflare-dns=ABSENT
direct       cert-manager=[fake]   cloudflare-dns=[fake]
```

`internal` correctly omits both secrets (`dns.provider = "none"`). Reverting one template to `cloudflare.token` reproduces the empty decrypt, confirming this is the whole cause. Validator suite: 39 passed.

## Follow-ups (not in this PR)

Two gaps let this reach `main`, both worth addressing separately:

1. **`undefined = "chainable"` masks renames.** Strict undefined would have failed the render loudly at PR time. Left alone here since it may break intentional undefined use elsewhere.
2. **No test asserts secret *contents*.** The e2e job renders and schema-validates, so an empty-but-well-formed secret passes. Asserting that `dns.token` round-trips through decrypt would catch this class directly.