### PR TITLE
fix(template): render with strict undefined, reject empty key material

### DIFF
--- a/makejinja.toml
+++ b/makejinja.toml
@@ -8,7 +8,7 @@ loaders = ["plugin:Plugin"]
 jinja_suffix = ".j2"
 copy_metadata = true
 force = true
-undefined = "chainable"
+undefined = "strict"
 
 [makejinja.delimiter]
 block_start = "#%"

--- a/template/scripts/plugin.py
+++ b/template/scripts/plugin.py
@@ -41,6 +41,8 @@ def cloudflare_tunnel_id(file_path: str = 'cloudflare-tunnel.json') -> str:
         tunnel_id = data.get("TunnelID")
         if tunnel_id is None:
             raise KeyError(f"Missing 'TunnelID' key in {file_path}")
+        if not tunnel_id:
+            raise ValueError(f"'TunnelID' is empty in {file_path}")
         return tunnel_id
 
     except FileNotFoundError:
@@ -58,6 +60,9 @@ def cloudflare_tunnel_secret(file_path: str = 'cloudflare-tunnel.json') -> str:
     try:
         with open(file_path, 'r') as file:
             data = json.load(file)
+        for field in ("AccountTag", "TunnelID", "TunnelSecret"):
+            if not data[field]:
+                raise ValueError(f"'{field}' is empty in {file_path}")
         transformed_data = {
             "a": data["AccountTag"],
             "t": data["TunnelID"],
@@ -80,7 +85,10 @@ def cloudflare_tunnel_secret(file_path: str = 'cloudflare-tunnel.json') -> str:
 def deploy_key(file_path: str = 'deploy.key') -> str:
     try:
         with open(file_path, 'r') as file:
-            return file.read().strip()
+            key = file.read().strip()
+        if not key:
+            raise ValueError(f"{file_path} is empty")
+        return key
     except FileNotFoundError:
         raise FileNotFoundError(f"File not found: {file_path}")
     except Exception as e:
@@ -91,7 +99,10 @@ def deploy_key(file_path: str = 'deploy.key') -> str:
 def webhook_token(file_path: str = 'flux-webhook-token.txt') -> str:
     try:
         with open(file_path, 'r') as file:
-            return file.read().strip()
+            token = file.read().strip()
+        if not token:
+            raise ValueError(f"{file_path} is empty")
+        return token
     except FileNotFoundError:
         raise FileNotFoundError(f"File not found: {file_path}")
     except Exception as e:

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -358,7 +358,10 @@ def load(config_file: str = "cluster.toml") -> dict[str, Any]:
     except ValidationError as e:
         raise ConfigError(format_errors(e)) from None
 
-    return config.model_dump(mode="json", exclude_none=True)
+    # Unset optionals stay in the dump as None rather than being dropped:
+    # makejinja renders with StrictUndefined, so a template testing
+    # network.vlan_tag needs the key to exist.
+    return config.model_dump(mode="json")
 
 
 def main() -> int:


### PR DESCRIPTION
Follow-ups from #2311, which fixed the symptom (two secrets rendering a blank `api-token` after the `cloudflare.token` → `dns.token` rename) but not the reason it shipped silently.

Two commits, each closing a distinct way a blank secret reaches SOPS.

## 1. Render with `StrictUndefined`

`makejinja.toml` set `undefined = "chainable"`, so a template reading a config key that no longer exists rendered an empty string rather than failing. `just configure` succeeded, kubeconform passed, SOPS encrypted the blank value, and the breakage only appeared on decrypt — or at runtime, when cert-manager and external-dns failed to authenticate.

With `undefined = "strict"` the same mistake aborts the render:

```
jinja2.exceptions.UndefinedError: 'cloudflare' is undefined
```

This requires dropping `exclude_none` from the config dump in `validate.py`. Templates test optional fields (`#% if network.vlan_tag %#`), and `exclude_none=True` removed unset optionals from the data entirely — which strict mode treats as an error rather than a falsy `None`. Keeping the keys present as `None` preserves every existing truthiness check.

## 2. Reject empty key material and tunnel fields

Strict undefined covers keys read from `cluster.toml`; pydantic already rejects an empty `dns.token` or `domain.name`. What neither covers is the plugin readers for on-disk key material. `age_key` refuses an `age.key` it cannot parse, but the others returned whatever they found:

| Input | Before | After |
|---|---|---|
| empty `flux-webhook-token.txt` | blank `token` in the flux-instance secret | render aborts |
| empty `deploy.key` | blank deploy-key secret | render aborts |
| `cloudflare-tunnel.json` with `""` fields | `TUNNEL_TOKEN` base64-decoding to empty credentials | render aborts |
| empty `age.key` | already aborted | unchanged |

`just init` won't repair these — it only creates a file when absent (`[ -f ... ] ||`), so an empty one persists across runs.

Errors name the offending file:

```
RuntimeError: Unexpected error while reading flux-webhook-token.txt: flux-webhook-token.txt is empty
RuntimeError: Unexpected error while processing cloudflare-tunnel.json: 'TunnelSecret' is empty in cloudflare-tunnel.json
```

I first wrote this as a `validate-secrets` recipe that scanned the plaintext render for empty values. It was the wrong shape: redundant with strict undefined and pydantic for every config-sourced value, and it *missed* the tunnel case entirely, because `cloudflare_tunnel_secret` base64-encodes a JSON wrapper and so is never literally empty. Guarding at the reader covers all four inputs in 13 lines, with no `yq` call added to `configure`.

## Verification

- **Renders are byte-identical to `main`** across all six valid fixtures (`public`, `private`, `selfhosted`, `no-webhook`, `internal`, `direct`), diffed file-by-file with identical key material. This is the load-bearing check for the `exclude_none` removal.
- `just configure` green on all six fixtures.
- Strict undefined fires on a renamed key: `dns.token` → `dns.tokne` aborts with `UndefinedError`, exit 1.
- Each of the four blank-input cases above aborts with exit 1; verified individually.
- 20/20 invalid fixtures still rejected, 6/6 valid still accepted; pytest 39 passed.

## Note

`just --fmt --check` reports drift on the root `justfile` on clean `main` too — pre-existing and untouched here. It does not match the `format-just` hook's `["*.just", ".justfile"]` glob, which is why it goes unnoticed. Worth a separate look.