### PR TITLE
docs: drop stale post-bootstrap commit step

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ These guidelines provide a strong baseline, but there are always exceptions and 
 
 4. Push your changes to git:
 
-    📍 _**Verify** all the `./kubernetes/**/*.sops.*` files are **encrypted** with SOPS_
+    📍 _**Verify** all the `./bootstrap/**/*.sops.*`, `./kubernetes/**/*.sops.*` and `./talos/secrets.sops.yaml` files are **encrypted** with SOPS_
 
     ```sh
     git add -A
@@ -163,21 +163,13 @@ These guidelines provide a strong baseline, but there are always exceptions and 
     just bootstrap talos
     ```
 
-2. Push your changes to git:
-
-    ```sh
-    git add -A
-    git commit -m "chore: add talos encrypted secret :lock:"
-    git push
-    ```
-
-3. Install cilium, coredns, spegel, flux and sync the cluster to the repository state:
+2. Install cilium, coredns, spegel, flux and sync the cluster to the repository state:
 
     ```sh
     just bootstrap apps
     ```
 
-4. Watch the rollout of your cluster happen:
+3. Watch the rollout of your cluster happen:
 
     ```sh
     kubectl get pods --all-namespaces --watch


### PR DESCRIPTION
Reported by a user following the README: the `git add -A` / `git commit` step after `just bootstrap talos` has nothing to commit.

Since the switch from talhelper to topf, `just configure` generates the secrets bundle — `validate-talos` runs `topf render`, which creates `talos/secrets.sops.yaml` on first run — so it is already included in the Stage 5 initial commit. `just bootstrap talos` afterwards writes only `talos/talosconfig` and `kubeconfig`, both gitignored, and `topf secrets` is a no-op on an existing bundle.

- Remove Stage 6 step 2 and renumber the remaining steps.
- Name `./bootstrap/**/*.sops.*` and `./talos/secrets.sops.yaml` alongside `./kubernetes/**/*.sops.*` in the Stage 5 encryption check, since those go in with the same commit.

Verified on a fresh clone: after `just init`, `just configure` and the Stage 5 commit, `git status --porcelain` is empty once the talos recipes have run.
