### PR TITLE
fix(template): render yaml in oxfmt canonical form

### DIFF
--- a/.github/template-tests/valid/single-node.toml
+++ b/.github/template-tests/valid/single-node.toml
@@ -1,0 +1,26 @@
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+
+[domain]
+name = "example.com"
+
+[dns]
+provider = "none"
+
+[repository]
+url = "https://github.com/onedr0p/cluster-template.git"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/workflows/template-e2e.yaml
+++ b/.github/workflows/template-e2e.yaml
@@ -130,6 +130,11 @@ jobs:
       - name: Run configure recipe
         run: just configure
 
+      # Rendered output must already match the format-yaml pre-commit hook,
+      # otherwise every `just configure` shows up as formatting churn.
+      - name: Assert rendered output is formatted
+        run: oxfmt --check ./.sops.yaml ./bootstrap ./kubernetes ./talos
+
       - name: Install flate
         uses: home-operations/flate/action@bf3405a189626478b0aa6ec98dc4d6f7d419df17 # v0.4.12
         with:

--- a/.github/workflows/template-e2e.yaml
+++ b/.github/workflows/template-e2e.yaml
@@ -106,6 +106,7 @@ jobs:
           - no-webhook
           - internal
           - direct
+          - single-node
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/template/config/bootstrap/helmfile/apps.yaml.j2
+++ b/template/config/bootstrap/helmfile/apps.yaml.j2
@@ -27,14 +27,14 @@ releases:
     namespace: kube-system
     inherit:
       - template: default
-    needs: ['kube-system/cilium']
-
+    needs: ["kube-system/cilium"]
   #% if spegel.enabled %#
+
   - name: spegel
     namespace: kube-system
     inherit:
       - template: default
-    needs: ['kube-system/coredns']
+    needs: ["kube-system/coredns"]
   #% endif %#
 
   - name: cert-manager
@@ -42,19 +42,19 @@ releases:
     inherit:
       - template: default
     #% if spegel.enabled %#
-    needs: ['kube-system/spegel']
+    needs: ["kube-system/spegel"]
     #% else %#
-    needs: ['kube-system/coredns']
+    needs: ["kube-system/coredns"]
     #% endif %#
 
   - name: flux-operator
     namespace: flux-system
     inherit:
       - template: default
-    needs: ['cert-manager/cert-manager']
+    needs: ["cert-manager/cert-manager"]
 
   - name: flux-instance
     namespace: flux-system
     inherit:
       - template: default
-    needs: ['flux-system/flux-operator']
+    needs: ["flux-system/flux-operator"]

--- a/template/config/talos/all/40-sysctls.yaml.j2
+++ b/template/config/talos/all/40-sysctls.yaml.j2
@@ -1,11 +1,11 @@
 machine:
   sysctls:
-    fs.inotify.max_user_watches: "1048576"     # Watchdog
-    fs.inotify.max_user_instances: "8192"      # Watchdog
-    net.core.rmem_max: "7500000"               # Cloudflared | QUIC
-    net.core.wmem_max: "7500000"               # Cloudflared | QUIC
-    net.ipv4.neigh.default.gc_thresh1: "4096"  # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192"  # Prevent ARP cache overflows
+    fs.inotify.max_user_watches: "1048576" # Watchdog
+    fs.inotify.max_user_instances: "8192" # Watchdog
+    net.core.rmem_max: "7500000" # Cloudflared | QUIC
+    net.core.wmem_max: "7500000" # Cloudflared | QUIC
+    net.ipv4.neigh.default.gc_thresh1: "4096" # Prevent ARP cache overflows
+    net.ipv4.neigh.default.gc_thresh2: "8192" # Prevent ARP cache overflows
     net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.tcp_slow_start_after_idle: "0"    # Preserve congestion window after idle
-    user.max_user_namespaces: "11255"          # User Namespaces
+    net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
+    user.max_user_namespaces: "11255" # User Namespaces


### PR DESCRIPTION
Reported by a user: re-running `just configure` reshuffles yaml formatting in already-committed files.

Cause is the `format-yaml` pre-commit hook. It runs `oxfmt` over staged yaml with `stage_fixed = true`, so whatever lands in git is oxfmt-canonical, while makejinja renders the raw template text. Two templates were not in canonical form, so the drift came back on every render:

- `bootstrap/helmfile/apps.yaml` — single-quoted `needs:` entries, plus a doubled blank line when the spegel release is skipped (`spegel.enabled` defaults to `len(nodes) > 1`, so single-node clusters hit this).
- `talos/all/40-sysctls.yaml` — comments padded into a column, which oxfmt collapses to a single space.

Both templates now render what oxfmt would produce, and the e2e job asserts it so future template edits cannot reintroduce the drift.

Verified locally on a fresh clone: all six valid fixtures, each rendered both as-is and trimmed to a single node (12 renders), are now `oxfmt --check` clean over `.sops.yaml`, `bootstrap/`, `kubernetes/` and `talos/`. Rendered release graph is unchanged in both spegel states.

Also adds a `single-node` fixture to the `validate-valid` matrix. `spegel.enabled` defaults to `len(nodes) > 1`, so the skipped-spegel path — the one that produced the doubled blank line — had no fixture and the new formatting check could not have caught drift in it. The fixture is `internal.toml` with one node, so node count is the only variable it changes.

Locally, that fixture passes every step the job runs: `just configure`, `oxfmt --check`, `just talos render` + `talosctl validate` (`k8s-0.yaml is valid for metal mode`), `just template test-helmfile`, and both bootstrap dry runs. Rendered release graph drops the spegel release and points cert-manager at coredns.
