### PR TITLE
fix(template): keep unchanged secrets untouched on rerun

### DIFF
--- a/.github/workflows/template-e2e.yaml
+++ b/.github/workflows/template-e2e.yaml
@@ -136,6 +136,17 @@ jobs:
       - name: Assert rendered output is formatted
         run: oxfmt --check ./.sops.yaml ./bootstrap ./kubernetes ./talos
 
+      # Rerunning configure against an unchanged cluster.toml must be a no-op.
+      # sops picks a fresh data key on every encrypt, so an unchanged secret
+      # comes back as a diff unless encrypt-secrets keeps the stashed copy.
+      - name: Assert configure is idempotent
+        run: |
+          git add --all
+          git -c core.hooksPath=/dev/null -c user.name=ci -c user.email=ci@local \
+            commit --quiet --message rendered
+          just configure
+          git diff --exit-code
+
       - name: Install flate
         uses: home-operations/flate/action@bf3405a189626478b0aa6ec98dc4d6f7d419df17 # v0.4.12
         with:

--- a/template/mod.just
+++ b/template/mod.just
@@ -23,7 +23,7 @@ cloudflare_tunnel := justfile_dir() + '/cloudflare-tunnel.json'
 
 [doc('Render and validate configuration files')]
 [group('template')]
-configure: render encrypt-secrets validate-kubernetes validate-talos
+configure: render encrypt-secrets restore-secrets validate-kubernetes validate-talos
 
 [doc('Check that all prerequisite files exist and cluster.toml validates against the schema')]
 [group('template')]
@@ -110,6 +110,22 @@ encrypt-secrets:
 [private]
 render:
     PYTHONDONTWRITEBYTECODE=1 uv run --locked makejinja
+
+# sops picks a fresh data key on every encrypt, so re-rendering a secret whose
+# values did not change still rewrites the whole file. Both sides are compared
+# decrypted, which is also how sops normalises them. Untracked secrets and
+# repos without a commit yet never show up in the diff, so they are left as-is.
+[private]
+restore-secrets:
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+    git diff --name-only -z -- '*.sops.*' \
+        | while IFS= read -r -d '' f; do
+            if diff -q \
+                    <(git show ":$f" | sops decrypt --input-type yaml --output-type yaml /dev/stdin) \
+                    <(sops decrypt "$f") >/dev/null 2>&1; then
+                git restore -- "$f"
+            fi
+        done
 
 [private]
 tidy-archive:


### PR DESCRIPTION
Reported by a user: every `just configure` rerun rewrites all seven `*.sops.yaml` files, so they keep running `git restore` afterwards to undo it.

`makejinja` renders each secret back to plaintext (`force = true`), then `encrypt-secrets` re-encrypts it, and sops picks a fresh data key on every encrypt. sops offers no way to ask whether a secret actually needs re-encrypting — `filestatus` only reports whether a file *is* encrypted, `encrypt` has no skip-if-unchanged flag, and encrypting identical plaintext twice differs on every line. Even `sops set` with the value a file already holds still rewrites `lastmodified` and `mac`.

So the comparison has to happen on decrypted content. Git already stores the old ciphertext, and running both sides through `sops decrypt` normalises them identically, so the whole fix is one loop over what git already reports as changed:

```
git diff --name-only -z -- '*.sops.*' | while read -d '' f; do
    if diff -q <(git show ":$f" | sops decrypt …/dev/stdin) <(sops decrypt "$f"); then
        git restore -- "$f"
    fi
done
```

That is the reporter's manual `git restore`, made conditional on the plaintext being unchanged. Secrets whose values really changed keep their new ciphertext. Untracked secrets, a repo with no commit yet, and a tree that is not a git repo at all never reach the comparison and are left encrypted as before.

The e2e job now commits the rendered output and asserts a second `just configure` leaves no diff. The guard is not vacuous: without this fix it fails with 7 modified files.

Verified locally on fresh clones:

- All seven valid fixtures: `configure`, commit, `configure` again → `git status` empty, `oxfmt --check` still clean.
- Changes still propagate and stay scoped: `domain.name` touches only `cluster-secrets.sops.yaml` (decrypts to the new domain); `dns.token` touches only the cert-manager and cloudflare-dns secrets.
- Interrupted run (plaintext left in the tree by a bare `render`): next `configure` re-encrypts, then restores, leaving no diff.
- Repo with no commits, and a tree with no `.git` at all: `configure` succeeds and secrets stay encrypted.
