### PR TITLE
ci(e2e): adopt talosctl-cluster-action v0.1.6

### DIFF
--- a/.github/template-tests/e2e/cluster.sh
+++ b/.github/template-tests/e2e/cluster.sh
@@ -102,18 +102,21 @@ start_local_git_server() {
 }
 
 prepare() {
+# In CI the action itself waits for every node's maintenance API before
+# returning, so the poll here covers only the local path, where cluster
+# create returns as soon as the VMs launch.
 if [ "$PROVISIONED" = false ]; then
     echo "==> booting maintenance-mode nodes"
     (cd "$STATE" && sudo -E env TALOSCONFIG="$STATE/talosconfig" \
         "$TALOSCTL" cluster create qemu --name "$NAME" --presets iso,maintenance \
         --controlplanes 1 --workers 1 --cidr "$CIDR" \
         --memory-controlplanes 4GiB --memory-workers 3GiB)
-fi
 
-echo "==> waiting for the maintenance API"
-for ip in "${NODES[@]}"; do
-    until talosctl -n "$ip" get links --insecure >/dev/null 2>&1; do sleep 5; done
-done
+    echo "==> waiting for the maintenance API"
+    for ip in "${NODES[@]}"; do
+        until talosctl -n "$ip" get links --insecure >/dev/null 2>&1; do sleep 5; done
+    done
+fi
 
 echo "==> discovering node hardware"
 declare -A MACS DISKS

--- a/.github/workflows/template-e2e-cluster.yaml
+++ b/.github/workflows/template-e2e-cluster.yaml
@@ -63,9 +63,10 @@ jobs:
 
       - name: Boot maintenance-mode nodes
         id: cluster
-        uses: home-operations/talosctl-cluster-action@97d173e2efba3ec61abbfdf0fbd78ed848608190 # v0.1.4
+        uses: home-operations/talosctl-cluster-action@42a2d1c476f87245e2d1882ec825fb31368b9686 # v0.1.6
         with:
           config: ./.github/template-tests/e2e/talos-cluster.yaml
+          cache: true
 
       - name: Export cluster environment
         env:


### PR DESCRIPTION
Bumps the e2e cluster action pin from v0.1.4 to [v0.1.6](https://github.com/home-operations/talosctl-cluster-action/releases/tag/v0.1.6) and adopts two of its features:

- **`cache: true`** — the Image Factory boot assets (`~/.talos/cache`) ride the Actions cache, keyed on Talos version/schematic/presets/factory URL, so only the first run per combination downloads the ISO. With the nightly cron plus PR runs, that saves the boot-media download on every run after the first per Talos version.
- **Maintenance API wait** — the action now polls until every node accepts a connection on port 50000 before returning, so `cluster.sh`'s own "waiting for the maintenance API" loop moves inside the local-provisioning path, where raw `talosctl cluster create` still returns as soon as the VMs launch. In CI the very next `--insecure` calls (hardware discovery) assert the action kept its promise, so a wait regression fails loudly instead of being papered over.

The third v0.1.6 feature, `${GATEWAY}` patch substitution, does not apply here — the maintenance-mode nodes take no config patches, and the workflow already consumes the `gateway` output.