### PR TITLE
fix(template): size replicas by node role, harden coredns and kubelet

### DIFF
--- a/.github/template-tests/valid/multi-controller.toml
+++ b/.github/template-tests/valid/multi-controller.toml
@@ -1,0 +1,42 @@
+[network]
+node_cidr = "10.10.10.0/24"
+
+[kubernetes.api]
+addr = "10.10.10.254"
+
+[gateways]
+internal = "10.10.10.252"
+dns      = "10.10.10.253"
+
+[repository]
+url = "ssh://git@github.com/onedr0p/cluster-template.git"
+
+[domain]
+name = "example.com"
+
+[dns]
+provider = "none"
+
+[[nodes]]
+name         = "k8s-0"
+address      = "10.10.10.100"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:00"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
+[[nodes]]
+name         = "k8s-1"
+address      = "10.10.10.101"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:01"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"
+
+[[nodes]]
+name         = "k8s-2"
+address      = "10.10.10.102"
+controller   = true
+disk         = "/dev/sdfake"
+mac_addr     = "00:00:00:00:00:02"
+schematic_id = "376567988ad370138ad8b2698212367b8edcb69b5fd68c80be1f2ec7d603b4ba"

--- a/.github/workflows/template-e2e.yaml
+++ b/.github/workflows/template-e2e.yaml
@@ -107,6 +107,7 @@ jobs:
           - internal
           - direct
           - single-node
+          - multi-controller
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/template-e2e.yaml
+++ b/.github/workflows/template-e2e.yaml
@@ -62,13 +62,13 @@ jobs:
       - name: Assert schema rejects ${{ matrix.fixture }}.toml
         run: |
           fixture=./.github/template-tests/invalid/${{ matrix.fixture }}.toml
-          if uv run --quiet --locked ./template/scripts/validate.py "$fixture" >/dev/null 2>&1; then
+          if uv run --quiet --locked --no-dev ./template/scripts/validate.py "$fixture" >/dev/null 2>&1; then
             echo "::error::schema accepted invalid fixture ${{ matrix.fixture }} (expected rejection)"
             exit 1
           fi
           echo "schema correctly rejected ${{ matrix.fixture }}"
           # Also surface the actual error message in the log for debuggability.
-          uv run --quiet --locked ./template/scripts/validate.py "$fixture" || true
+          uv run --quiet --locked --no-dev ./template/scripts/validate.py "$fixture" || true
 
   validator-tests:
     if: ${{ github.repository == 'onedr0p/cluster-template' }}

--- a/template/config/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/cert-manager/cert-manager/app/helmrelease.yaml.j2
@@ -11,7 +11,7 @@ spec:
   values:
     crds:
       enabled: true
-    replicaCount: 1
+    replicaCount: #{ 2 if nodes | length > 1 else 1 }#
     dns01RecursiveNameservers: https://1.1.1.1:443/dns-query,https://1.0.0.1:443/dns-query
     dns01RecursiveNameserversOnly: true
     prometheus:

--- a/template/config/kubernetes/apps/default/echo/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/default/echo/app/helmrelease.yaml.j2
@@ -9,7 +9,7 @@ spec:
     name: echo
   interval: 1h
   values:
-    replicaCount: 2
+    replicaCount: #{ 2 if nodes | length > 1 else 1 }#
     config:
       kubernetes: true
       trustedProxies:

--- a/template/config/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -58,7 +58,7 @@ spec:
         enabled: true
         serviceMonitor:
           enabled: true
-      replicas: 1
+      replicas: #{ 2 if nodes | length > 1 else 1 }#
       rollOutPods: true
     prometheus:
       enabled: true

--- a/template/config/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
+++ b/template/config/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml.j2
@@ -18,7 +18,8 @@ spec:
     service:
       name: kube-dns
       clusterIP: "#{ kubernetes.coredns_addr }#"
-    replicaCount: 2
+    replicaCount: #{ 2 if controller_count > 1 else 1 }#
+    priorityClassName: system-cluster-critical
     servers:
       - zones:
           - zone: .
@@ -44,6 +45,7 @@ spec:
             configBlock: |-
               prefetch 20
               serve_stale
+              servfail 0
           - name: loop
           - name: reload
           - name: loadbalance

--- a/template/config/kubernetes/apps/network/envoy-gateway/app/envoy.yaml.j2
+++ b/template/config/kubernetes/apps/network/envoy-gateway/app/envoy.yaml.j2
@@ -11,7 +11,7 @@ spec:
     type: Kubernetes
     kubernetes:
       envoyDeployment:
-        replicas: 2
+        replicas: #{ 2 if nodes | length > 1 else 1 }#
         container:
           imageRepository: mirror.gcr.io/envoyproxy/envoy
           resources:

--- a/template/config/talos/all/30-kubelet.yaml.j2
+++ b/template/config/talos/all/30-kubelet.yaml.j2
@@ -1,6 +1,9 @@
 machine:
   kubelet:
     extraConfig:
+      crashLoopBackOff:
+        maxContainerRestartPeriod: 60s
+      imageMaximumGCAge: 168h
       maxParallelImagePulls: 3
       serializeImagePulls: false
       shutdownGracePeriod: 90s

--- a/template/config/talos/control-plane/00-cluster.yaml.j2
+++ b/template/config/talos/control-plane/00-cluster.yaml.j2
@@ -25,3 +25,14 @@ cluster:
   scheduler:
     extraArgs:
       bind-address: 0.0.0.0
+    config:
+      profiles:
+        - schedulerName: default-scheduler
+          pluginConfig:
+            - name: PodTopologySpread
+              args:
+                defaultingType: List
+                defaultConstraints:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: ScheduleAnyway

--- a/template/mod.just
+++ b/template/mod.just
@@ -48,7 +48,7 @@ doctor:
             just log info "ok" check schema
         else
             just log error "fail" check schema
-            just log info "diagnose with: uv run --locked {{ validate_script }} {{ config_file }}"
+            just log info "diagnose with: uv run --locked --no-dev {{ validate_script }} {{ config_file }}"
             rc=1
         fi
     fi
@@ -81,7 +81,7 @@ tidy: tidy-preconditions tidy-strip && tidy-archive
 # config is invalid.
 [private]
 config-json:
-    uv run --quiet --locked "{{ validate_script }}" "{{ config_file }}"
+    uv run --quiet --locked --no-dev "{{ validate_script }}" "{{ config_file }}"
 
 [no-exit-message]
 [private]
@@ -109,7 +109,7 @@ encrypt-secrets:
 
 [private]
 render:
-    PYTHONDONTWRITEBYTECODE=1 uv run --locked makejinja
+    PYTHONDONTWRITEBYTECODE=1 uv run --locked --no-dev makejinja
 
 [private]
 tidy-archive:

--- a/template/scripts/plugin.py
+++ b/template/scripts/plugin.py
@@ -8,105 +8,80 @@ import re
 import validate
 
 
+# Return the stripped contents of file_path, rejecting a missing or empty file
+def _read_stripped(file_path: str) -> str:
+    try:
+        content = Path(file_path).read_text().strip()
+    except FileNotFoundError:
+        raise FileNotFoundError(f"File not found: {file_path}") from None
+    if not content:
+        raise ValueError(f"{file_path} is empty")
+    return content
+
+
+# Return the parsed contents of a JSON file
+def _read_json(file_path: str) -> dict[str, Any]:
+    try:
+        return json.loads(_read_stripped(file_path))
+    except json.JSONDecodeError:
+        raise ValueError(f"Could not decode JSON file: {file_path}") from None
+
+
 # Return the age public or private key from age.key
 def age_key(key_type: str, file_path: str = 'age.key') -> str:
-    try:
-        with open(file_path, 'r') as file:
-            file_content = file.read().strip()
-        if key_type == 'public':
-            # Matches both classic (age1...) and post-quantum (age1pq1...) recipients
-            key_match = re.search(r"# public key: (age1[\w]+)", file_content)
-            if not key_match:
-                raise ValueError("Could not find public key in the age key file.")
-            return key_match.group(1)
-        elif key_type == 'private':
-            # (?:PQ-)? matches post-quantum identities (AGE-SECRET-KEY-PQ-1...) as well as classic ones
-            key_match = re.search(r"(AGE-SECRET-KEY-(?:PQ-)?1[\w]+)", file_content)
-            if not key_match:
-                raise ValueError("Could not find private key in the age key file.")
-            return key_match.group(1)
-        else:
-            raise ValueError("Invalid key type. Use 'public' or 'private'.")
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error while processing {file_path}: {e}")
+    file_content = _read_stripped(file_path)
+    if key_type == 'public':
+        # Matches both classic (age1...) and post-quantum (age1pq1...) recipients
+        key_match = re.search(r"# public key: (age1[\w]+)", file_content)
+        if not key_match:
+            raise ValueError("Could not find public key in the age key file.")
+        return key_match.group(1)
+    elif key_type == 'private':
+        # (?:PQ-)? matches post-quantum identities (AGE-SECRET-KEY-PQ-1...) as well as classic ones
+        key_match = re.search(r"(AGE-SECRET-KEY-(?:PQ-)?1[\w]+)", file_content)
+        if not key_match:
+            raise ValueError("Could not find private key in the age key file.")
+        return key_match.group(1)
+    else:
+        raise ValueError("Invalid key type. Use 'public' or 'private'.")
 
 
 # Return cloudflare tunnel fields from cloudflare-tunnel.json
 def cloudflare_tunnel_id(file_path: str = 'cloudflare-tunnel.json') -> str:
-    try:
-        with open(file_path, 'r') as file:
-            data = json.load(file)
-        tunnel_id = data.get("TunnelID")
-        if tunnel_id is None:
-            raise KeyError(f"Missing 'TunnelID' key in {file_path}")
-        if not tunnel_id:
-            raise ValueError(f"'TunnelID' is empty in {file_path}")
-        return tunnel_id
-
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except json.JSONDecodeError:
-        raise ValueError(f"Could not decode JSON file: {file_path}")
-    except KeyError as e:
-        raise KeyError(f"Error in JSON structure: {e}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error while processing {file_path}: {e}")
+    data = _read_json(file_path)
+    tunnel_id = data.get("TunnelID")
+    if tunnel_id is None:
+        raise KeyError(f"Missing 'TunnelID' key in {file_path}")
+    if not tunnel_id:
+        raise ValueError(f"'TunnelID' is empty in {file_path}")
+    return tunnel_id
 
 
 # Return cloudflare tunnel fields from cloudflare-tunnel.json in TUNNEL_TOKEN format
 def cloudflare_tunnel_secret(file_path: str = 'cloudflare-tunnel.json') -> str:
-    try:
-        with open(file_path, 'r') as file:
-            data = json.load(file)
-        for field in ("AccountTag", "TunnelID", "TunnelSecret"):
-            if not data[field]:
-                raise ValueError(f"'{field}' is empty in {file_path}")
-        transformed_data = {
-            "a": data["AccountTag"],
-            "t": data["TunnelID"],
-            "s": data["TunnelSecret"]
-        }
-        json_string = json.dumps(transformed_data, separators=(',', ':'))
-        return base64.b64encode(json_string.encode('utf-8')).decode('utf-8')
-
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except json.JSONDecodeError:
-        raise ValueError(f"Could not decode JSON file: {file_path}")
-    except KeyError as e:
-        raise KeyError(f"Missing key in JSON file {file_path}: {e}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error while processing {file_path}: {e}")
+    data = _read_json(file_path)
+    for field in ("AccountTag", "TunnelID", "TunnelSecret"):
+        if field not in data:
+            raise KeyError(f"Missing '{field}' key in {file_path}")
+        if not data[field]:
+            raise ValueError(f"'{field}' is empty in {file_path}")
+    transformed_data = {
+        "a": data["AccountTag"],
+        "t": data["TunnelID"],
+        "s": data["TunnelSecret"]
+    }
+    json_string = json.dumps(transformed_data, separators=(',', ':'))
+    return base64.b64encode(json_string.encode('utf-8')).decode('utf-8')
 
 
 # Return the Flux deploy key from deploy.key
 def deploy_key(file_path: str = 'deploy.key') -> str:
-    try:
-        with open(file_path, 'r') as file:
-            key = file.read().strip()
-        if not key:
-            raise ValueError(f"{file_path} is empty")
-        return key
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error while reading {file_path}: {e}")
+    return _read_stripped(file_path)
 
 
 # Return the Flux webhook token from flux-webhook-token.txt
 def webhook_token(file_path: str = 'flux-webhook-token.txt') -> str:
-    try:
-        with open(file_path, 'r') as file:
-            token = file.read().strip()
-        if not token:
-            raise ValueError(f"{file_path} is empty")
-        return token
-    except FileNotFoundError:
-        raise FileNotFoundError(f"File not found: {file_path}")
-    except Exception as e:
-        raise RuntimeError(f"Unexpected error while reading {file_path}: {e}")
+    return _read_stripped(file_path)
 
 
 CONFIG_FILE = 'cluster.toml'

--- a/template/scripts/test_validate.py
+++ b/template/scripts/test_validate.py
@@ -95,9 +95,20 @@ def test_spegel_enabled_follows_node_count():
     assert _load_raw(explicit).spegel.enabled is False
 
 
+def test_controller_count_ignores_workers():
+    raw = config_from("private.toml")
+    assert [n["controller"] for n in raw["nodes"]] == [True, False]
+    assert _load_raw(raw).controller_count == 1
+    raw["nodes"][1]["controller"] = True
+    assert _load_raw(raw).controller_count == 2
+
+
 def test_derived_fields_are_not_settable():
     raw = config_from("public.toml", cilium_bgp_enabled=True)
     with pytest.raises(ConfigError, match="cilium_bgp_enabled"):
+        _load_raw(raw)
+    raw = config_from("public.toml", controller_count=3)
+    with pytest.raises(ConfigError, match="controller_count"):
         _load_raw(raw)
 
 

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -236,6 +236,13 @@ class Config(Model):
         bgp = self.cilium.bgp
         return bgp.router_addr != "" and bgp.router_asn != "" and bgp.node_asn != ""
 
+    # Replica counts for control-plane-only workloads key off this rather
+    # than len(nodes); a cluster can have many workers but one controller.
+    @computed_field
+    @property
+    def controller_count(self) -> int:
+        return sum(1 for node in self.nodes if node.controller)
+
     @computed_field
     @property
     def cluster_issuer(self) -> str:

--- a/template/scripts/validate.py
+++ b/template/scripts/validate.py
@@ -1,6 +1,6 @@
 """Validate cluster.toml, apply defaults, and emit the config as JSON.
 
-Standalone usage (doctor, CI): uv run --locked template/scripts/validate.py [cluster.toml]
+Standalone usage (doctor, CI): uv run --locked --no-dev template/scripts/validate.py [cluster.toml]
 In-process usage (makejinja plugin): from validate import load
 
 Exits non-zero with one human-readable error per line on stderr when the


### PR DESCRIPTION
Replica counts in the template were fixed constants that ignored cluster shape, in both directions. Plus coredns/kubelet hardening and a scheduler-level default spread.

## Replica counts now follow cluster shape

| Component | Before | After | Keyed on |
| --- | --- | --- | --- |
| cilium operator | 1 | 2 when multi-node | node count |
| coredns | 2 | 2 when multi-controller | **controller count** |
| cert-manager | 1 | 2 when multi-node | node count |
| echo | 2 | 2 when multi-node | node count |
| envoy | 2 | 2 when multi-node | node count |

**Cilium** was pinned at one, so any node reboot or Talos upgrade landing on the operator's node left the cluster without an operator until it rescheduled. Single-node stays at one because chart 1.20.0 sets `operator.affinity` to a **required** `podAntiAffinity` on `kubernetes.io/hostname` ("cilium-operator pods must not be scheduled on the same node as they will clash") — a second replica would sit `Pending` forever.

**CoreDNS** is the inverse bug, and the one that needs a different count. It's pinned to the control plane by a required `nodeAffinity`, and the template replaces the chart's `affinity` block wholesale, dropping the pod anti-affinity that would otherwise separate the replicas. On the common one-controller layout both hardcoded replicas landed on the same node: no availability gain, double the resources. Counting nodes would not have fixed it — every existing fixture has 2 nodes but only 1 controller.

**cert-manager** was pinned at one despite the controller doing leader election. **echo** and **envoy** were pinned at two regardless of size, costing a redundant pod on single-node clusters.

## Default pod spreading at the scheduler

```yaml
cluster:
  scheduler:
    config:
      profiles:
        - schedulerName: default-scheduler
          pluginConfig:
            - name: PodTopologySpread
              args:
                defaultingType: List
                defaultConstraints:
                  - maxSkew: 1
                    topologyKey: kubernetes.io/hostname
                    whenUnsatisfiable: ScheduleAnyway
```

Applies a soft hostname spread to every pod that doesn't declare its own `topologySpreadConstraints`, so the scaled components land on separate nodes without each chart needing its own constraints. `ScheduleAnyway` keeps it a preference — nothing becomes unschedulable when a spread isn't possible.

This replaces the built-in `System` defaulting, which also spreads by zone — meaningless on a homelab cluster with no zone labels.

Note this does not relax chart-supplied **required** anti-affinity, which is evaluated independently. Cilium's single-node branch above is still load-bearing.

## CoreDNS hardening

- `priorityClassName: system-cluster-critical` so DNS outranks ordinary workloads under eviction pressure.
- `servfail 0` in the cache block, disabling the default 5s SERVFAIL cache that pins transient upstream failures in place past recovery.

## Kubelet

```yaml
crashLoopBackOff:
  maxContainerRestartPeriod: 60s
imageMaximumGCAge: 168h
```

Caps backoff growth at 60s instead of the internal 300s maximum, and expires images unused for a week so node disks don't accumulate old layers.

Verified against k8s v1.36.3 (the pinned `kubernetesVersion`) rather than assumed:

| Field | Gate | Status at 1.36 | Constraint |
| --- | --- | --- | --- |
| `imageMaximumGCAge` | `ImageMaximumGCAge` | GA + `LockToDefault` since 1.35 | must exceed `imageMinimumGCAge` (default 2m) ✓ |
| `crashLoopBackOff.maxContainerRestartPeriod` | `KubeletCrashLoopBackOffMax` | Beta, default true since 1.35 | must be 1s–300s ✓ |

Both gates are on by default, so neither needs a `featureGates` entry. Neither field is in Talos `ProtectedConfigurationFields` (v1.13.7), so both are settable via `machine.kubelet.extraConfig`.

## New `controller_count` derived field

Added alongside `cilium_bgp_enabled` / `cluster_issuer` / `cert_sans` in `validate.py`, so "how many control-plane nodes" has one definition instead of an inline `selectattr` in each template that needs it.

## New `multi-controller` fixture

Every existing fixture has exactly one controller, so nothing in CI would have exercised the coredns 2-replica branch. Added a 3-controller fixture and wired it into the `accept-valid` matrix.

## Plugin file-reading consolidation

Unrelated to the replica work, folded in on request. The five Jinja helper functions in `plugin.py` each repeated the same open/strip and `FileNotFoundError` wrapping, and `deploy_key` and `webhook_token` were identical apart from a variable name. Extracted `_read_stripped` and `_read_json`; net -25 lines.

This also drops the per-function `except Exception` catch-alls, which is a small behavior change worth calling out. They rewrapped every failure as `RuntimeError("Unexpected error while processing ...")`, including the deliberate `ValueError`s raised inside the same `try` block. A malformed `age.key` now reports which check actually failed. Exception *types* change for those paths; since these are called during Jinja rendering, where any exception aborts the render, only the message the user sees differs.

Verified the five Jinja global names are unchanged (`age_key`, `cloudflare_tunnel_id`, `cloudflare_tunnel_secret`, `deploy_key`, `webhook_token`) — makejinja registers globals by `func.__name__`, so a rename would surface as an undefined-global failure at render under `undefined = "strict"`. Exercised every happy and error path directly, and rendered 5 fixtures through `just configure`.

## Skip the dev dependency group when rendering

uv installs the `dev` group by default, so every `just configure` was pulling pytest onto a user machine to render templates that never import it. Added `--no-dev` to the render, validate, and CI schema paths (6 call sites); the two pytest invocations keep the group they need.

Verified from a clean clone: `just configure` succeeds and the venv it builds has no pytest, and `just template doctor` passes. No churn in either direction either, which was the thing worth checking: once a contributor runs the suite and pytest lands in the venv, a later `configure` does not uninstall it.

## Testing

Rendered every shape in a scratch clone with `just configure`:

| Fixture | Nodes | Controllers | cilium | coredns | cert-manager | echo | envoy |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `single-node` | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `private` | 2 | 1 | 2 | **1** | 2 | 2 | 2 |
| `multi-controller` | 3 | 3 | 2 | **2** | 2 | 2 | 2 |

`private` is the case that motivates the split: two nodes, one controller, and coredns correctly disagrees with everything else.

- `helm template` of coredns 1.47.0 against the rendered values confirms `servfail 0` lands inside the `cache {}` block of the generated Corefile, plus `replicas` and `priorityClassName` on the Deployment. Kubeconform only checks the HelmRelease shape, not the Corefile the chart builds.
- `talosctl validate --config ... --mode metal` passes on all three rendered machine configs, and the scheduler block lands on control-plane nodes only.
- Scheduler `PodTopologySpreadArgs` field names checked against the v1.36.3 API, including the "`defaultingType` must be `List` when `defaultConstraints` is non-empty" rule. Talos injects `apiVersion`/`kind`/`clientConnection` itself and passes the rest through to the typed schema, so only `profiles` is supplied here.
- `uv run --locked pytest template/scripts/test_validate.py -q` — 41 passed.

The scheduler config is the one item `talosctl validate` cannot check — it's validated on the node at runtime, so the E2E Cluster job is the real gate for it.