### PR TITLE
feat(mise): add node to the required tool set

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -6,7 +6,7 @@ TALOSCONFIG = "{{config_root}}/talos/talosconfig"
 JUST_UNSTABLE = "1"
 
 [tools]
-uv = "0.12.1"                      # required:template
+uv = "0.12.1"                       # required:template
 age = "1.3.1"
 cloudflared = "2026.7.3"
 flux2 = "2.9.3"
@@ -20,6 +20,7 @@ kubeconform = "0.8.0"
 kubectl = "1.36.3"
 kustomize = "5.8.1"
 lefthook = "2.1.10"
+node = "24.19.0"
 oxfmt = "0.62.0"
 sd = "1.1.0"                        # required:template
 sops = "3.13.3"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -576,6 +576,38 @@ url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/leftho
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227505"
 provenance = "github-attestations"
 
+[[tools.node]]
+version = "24.19.0"
+backend = "core:node"
+
+[tools.node."platforms.linux-arm64"]
+checksum = "sha256:d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-arm64.tar.gz"
+
+[tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:20824e4d35948fae5b337dccef47813b04d8995312f59df7386f2256d9f9ab7e"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:f625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-linux-x64.tar.gz"
+
+[tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:c60223786df14a5d23e220ebb8e60318f5322640a62f90e6d9e54d3a18da532e"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64-musl.tar.gz"
+
+[tools.node."platforms.macos-arm64"]
+checksum = "sha256:8294b7aa9b03997481c06babf1e8b270c859358f27da57a11509afe537ac381d"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz"
+
+[tools.node."platforms.macos-x64"]
+checksum = "sha256:d1b5e999db158c62fe8f7267a4476b035d8bd93b1a605bac24a3f0dd166e3316"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-darwin-x64.tar.gz"
+
+[tools.node."platforms.windows-x64"]
+checksum = "sha256:57f71ab3652e797d84acddc79c81cc9ff1c6ddb2a1974cdb83f00fee9bff4c73"
+url = "https://nodejs.org/dist/v24.19.0/node-v24.19.0-win-x64.zip"
+
 [[tools.oxfmt]]
 version = "0.62.0"
 backend = "npm:oxfmt"


### PR DESCRIPTION
oxfmt is installed through mise's `npm:` backend. mise's `aube` package manager can fetch the tarball without npm, but the installed entrypoint is a shim that `exec`s `node`:

```sh
# aube-bin-shim v1
if [ -x "$basedir/node" ]; then exec "$basedir/node" ... ; else exec node ... ; fi
```

On a workstation with no node runtime, `mise install` succeeds but every oxfmt-backed lefthook command (`format-json`, `format-markdown`, `format-yaml`) fails with exit 127, so the initial `git commit` in Stage 3 of the README is blocked:

```
┃  format-yaml ❯
.../oxfmt: 8: exec: node: not found
exit status 127
```

Pinning node to the current LTS (24.19.0) lets mise supply the runtime oxfmt needs. Lockfile regenerated with `mise lock`.

Verified in a `debian:trixie` container with no `node`, `npm` or `python3`:

- before: `oxfmt: 8: exec: node: not found`, commit rejected
- after: node 24.19.0 installs, `format-yaml` and `format-markdown` pass, commit lands

Node 26 was not chosen deliberately — beyond not being LTS yet, its linux-x64 build needs `libatomic.so.1`, which is absent from a minimal Debian install. 24.19.0 has no such dependency.

Python needs no equivalent change: every python call goes through `uv run --locked --no-dev`, and uv auto-downloads CPython 3.14 when the system has none.