### PR TITLE
fix(renovate): allow talos group with two packages

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -6,7 +6,7 @@
     enabled: true,
     schedule: ["before 3am on the first day of the month"],
     commitMessageExtra: "({{manager}})",
-    additionalBranchPrefix: "{{manager}}-"
+    additionalBranchPrefix: "{{manager}}-",
   },
   packageRules: [
     {
@@ -25,8 +25,8 @@
     {
       description: "Talos Group",
       groupName: "talos",
-      matchPackageNames: ["ghcr.io/siderolabs/installer", "siderolabs/talos", "talosctl"],
-      minimumGroupSize: 3,
+      matchPackageNames: ["ghcr.io/siderolabs/installer", "talosctl"],
+      minimumGroupSize: 2,
     },
     {
       description: "Flux Operator Group",


### PR DESCRIPTION
The `talos` group added in #2302 requires `minimumGroupSize: 3`, but renovate only ever detects two matching packages here: `ghcr.io/siderolabs/installer` (regex comment in `template/config/talos/topf.yaml.j2`) and `talosctl` (mise). `siderolabs/talos` is never emitted as a dependency name; the mise manager reports the tool as `talosctl`, and the only occurrences of that string are lockfile URL metadata. The group could never be met, so renovate has been parking the Talos update under "Group Size Not Met" on #438 instead of opening the v1.13.9 PR.

Drops the dead `siderolabs/talos` entry and lowers `minimumGroupSize` to 2. Validated with `renovate-config-validator`.