### PR TITLE
fix(renovate): match talosctl by its package name in talos group

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -25,7 +25,7 @@
     {
       description: "Talos Group",
       groupName: "talos",
-      matchPackageNames: ["ghcr.io/siderolabs/installer", "talosctl"],
+      matchPackageNames: ["ghcr.io/siderolabs/installer", "siderolabs/talos"],
       minimumGroupSize: 2,
     },
     {


### PR DESCRIPTION
Follow-up to #2366, which removed the wrong name from the `talos` group. After it merged renovate opened the talosctl bump under `renovate/mise-tools` (#2367) and the dashboard still reported "Group Size Not Met" for the installer alone.

Renovate's mise manager resolves `talosctl` via its asdf tooling table with `packageName: 'siderolabs/talos'` and `depName: talosctl` (`lib/modules/manager/asdf/upgradeable-tooling.ts`), and `matchPackageNames` matches on `packageName`. So `siderolabs/talos` was the entry that matched talosctl all along; the bare `talosctl` name never matched anything. This restores `siderolabs/talos` and drops `talosctl`, keeping `minimumGroupSize: 2` so installer + talosctl land in one PR.

Validated with `renovate-config-validator`. Once this merges, renovate should move the talosctl update from #2367 into the `renovate/talos` branch together with the installer bump.