### PR TITLE
fix(renovate): use group commit topic for talos updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -19,7 +19,6 @@
       description: "Mise Tools Group",
       matchManagers: ["mise"],
       groupName: "mise tools",
-      groupSlug: "mise-tools",
       minimumReleaseAge: "3 days",
     },
     {

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -26,6 +26,9 @@
       description: "Talos Group",
       groupName: "talos",
       matchPackageNames: ["ghcr.io/siderolabs/installer", "siderolabs/talos"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
       minimumGroupSize: 2,
     },
     {


### PR DESCRIPTION
Grouped talos PRs currently get renovate's default group topic (`{{{groupName}}}`), producing `fix(container): update talos`. The flux-operator group already overrides this with `{{{groupName}}} group`; this applies the same override to the talos rule so its PRs read `update talos group`, matching the other group.

Also drops the explicit `groupSlug: "mise-tools"` from the mise tools rule. Renovate derives the slug from `groupName` and slugifies it when unset (`lib/workers/repository/updates/branch-name.ts`), so `"mise tools"` already yields `renovate/mise-tools`; the other groups rely on the same derivation. No branch name changes.

Validated with `renovate-config-validator`.