### PR TITLE
feat(talos)!: update to Talos 1.14 and topf 0.6.0

### DIFF
--- a/.github/workflows/template-e2e-cluster.yaml
+++ b/.github/workflows/template-e2e-cluster.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Boot maintenance-mode nodes
         id: cluster
-        uses: home-operations/talosctl-cluster-action@42a2d1c476f87245e2d1882ec825fb31368b9686 # v0.1.6
+        uses: home-operations/talosctl-cluster-action@fb6a31bf5de43218acc80d2e23958a16eee7380c # v0.2.2
         with:
           config: ./.github/template-tests/e2e/talos-cluster.yaml
           cache: true

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -6,7 +6,7 @@ TALOSCONFIG = "{{config_root}}/talos/talosconfig"
 JUST_UNSTABLE = "1"
 
 [tools]
-uv = "0.12.6"                       # required:template
+uv = "0.12.6"                        # required:template
 age = "1.3.1"
 cloudflared = "2026.8.2"
 flux2 = "2.9.4"
@@ -22,10 +22,10 @@ kustomize = "5.8.1"
 lefthook = "2.1.11"
 node = "24.20.0"
 oxfmt = "0.65.0"
-sd = "1.1.0"                        # required:template
+sd = "1.1.0"                         # required:template
 sops = "3.13.3"
-talosctl = "1.13.9"
-"github:postfinance/topf" = "v0.5.0"
+talosctl = "1.14.0"
+"github:postfinance/topf" = "v0.6.0"
 yq = "4.53.6"
 zizmor = "1.29.0"
 

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -92,23 +92,23 @@ url_api = "https://api.github.com/repos/cli/cli/releases/assets/522857972"
 provenance = "github-attestations"
 
 [[tools."github:postfinance/topf"]]
-version = "0.5.0"
+version = "0.6.0"
 backend = "github:postfinance/topf"
 
 [tools."github:postfinance/topf"."platforms.linux-arm64"]
-checksum = "sha256:d8aa6515ae9de54588fc0bba3fad9fe37a93c08cf20adc931baed4a67912cef1"
-url = "https://github.com/postfinance/topf/releases/download/v0.5.0/topf_linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/508553235"
+checksum = "sha256:7e5d4bf21f07ba91b83c4653eb65dd3cf5ee67aa8fa4131ca403b38791476367"
+url = "https://github.com/postfinance/topf/releases/download/v0.6.0/topf_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/542955869"
 
 [tools."github:postfinance/topf"."platforms.linux-x64"]
-checksum = "sha256:0a5ba8187887972acc7905cf12e804317b1869219bbf070d8dd2a9e29b70570c"
-url = "https://github.com/postfinance/topf/releases/download/v0.5.0/topf_linux_amd64.tar.gz"
-url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/508553236"
+checksum = "sha256:458df4b25f4181a31ed361c0592194f7eb9e6e7b13e7096f8745453afdeaadfb"
+url = "https://github.com/postfinance/topf/releases/download/v0.6.0/topf_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/542955866"
 
 [tools."github:postfinance/topf"."platforms.macos-arm64"]
-checksum = "sha256:e7de2cde889c1fba552a35c18e500f03ca120d79eb1a7643ee7503eb2572c166"
-url = "https://github.com/postfinance/topf/releases/download/v0.5.0/topf_darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/508553237"
+checksum = "sha256:48b22175d61eadba0c287411c34a90f73dbaa716fd792b7b28625d3edbf870e2"
+url = "https://github.com/postfinance/topf/releases/download/v0.6.0/topf_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/postfinance/topf/releases/assets/542955870"
 
 [[tools.gum]]
 version = "2.0.0"
@@ -349,25 +349,25 @@ url_api = "https://api.github.com/repos/getsops/sops/releases/assets/486808198"
 url = "https://github.com/getsops/sops/releases/download/v3.13.3/sops-v3.13.3.intoto.jsonl"
 
 [[tools.talosctl]]
-version = "1.13.9"
+version = "1.14.0"
 backend = "aqua:siderolabs/talos"
 
 [tools.talosctl."platforms.linux-arm64"]
-checksum = "sha256:51caed158eda73d2888cbf2df2d67551f9c9f8229aa42d3725e481d073e76f0b"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.9/talosctl-linux-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/520547649"
+checksum = "sha256:19615e1d0eb222de86ec2f1487e7d6e74f5171a9038e73aeacde8cc647e3d9e0"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-linux-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359013"
 provenance = "cosign"
 
 [tools.talosctl."platforms.linux-x64"]
-checksum = "sha256:7e1d4b7d5846964bdcf63a794e3c8161bb6ef2983d5ace58ea5322f3bf32a27e"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.9/talosctl-linux-amd64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/520547641"
+checksum = "sha256:2c147c4a99d124c95bd5c190fe054e0b3c93495f2243fd652ebd423adb8377c7"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-linux-amd64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359015"
 provenance = "cosign"
 
 [tools.talosctl."platforms.macos-arm64"]
-checksum = "sha256:ab4c27a959ff6c52f62c6cc2af07b22ca86ed27f1a138ed57582fa67f7b50f98"
-url = "https://github.com/siderolabs/talos/releases/download/v1.13.9/talosctl-darwin-arm64"
-url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/520547612"
+checksum = "sha256:f0c65a0e970b6f23cf0160e432e7496ba93957a49f369780d4e53888ed66ef46"
+url = "https://github.com/siderolabs/talos/releases/download/v1.14.0/talosctl-darwin-arm64"
+url_api = "https://api.github.com/repos/siderolabs/talos/releases/assets/542359001"
 provenance = "cosign"
 
 [[tools.uv]]

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -24,7 +24,7 @@
     {
       description: "Talos Group",
       groupName: "talos",
-      matchPackageNames: ["ghcr.io/siderolabs/installer", "siderolabs/talos"],
+      matchPackageNames: ["siderolabs/talos"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/template/config/talos/all/00-install.yaml.tpl.j2
+++ b/template/config/talos/all/00-install.yaml.tpl.j2
@@ -1,8 +1,9 @@
-machine:
-  install:
+apiVersion: v1alpha1
+kind: UnattendedInstallConfig
+provisioning:
+  diskSelector:
     {{- if .Node.Data.installDisk }}
-    disk: "{{ .Node.Data.installDisk }}"
+    match: disk.dev_path == "{{ .Node.Data.installDisk }}" || "{{ .Node.Data.installDisk }}" in disk.symlinks
     {{- else }}
-    diskSelector:
-      serial: "{{ .Node.Data.installDiskSerial }}"
+    match: disk.serial == "{{ .Node.Data.installDiskSerial }}"
     {{- end }}

--- a/template/config/talos/all/10-cluster.yaml.j2
+++ b/template/config/talos/all/10-cluster.yaml.j2
@@ -1,12 +1,10 @@
-# Disable built-in CNI to use Cilium
-cluster:
-  network:
-    cni:
-      name: none
-    podSubnets: ["#{ kubernetes.pod_cidr }#"]
-    serviceSubnets: ["#{ kubernetes.svc_cidr }#"]
 machine:
   certSANs:
     #% for item in cert_sans %#
     - "#{ item }#"
     #% endfor %#
+---
+apiVersion: v1alpha1
+kind: KubeNetworkConfig
+podSubnets: ["#{ kubernetes.pod_cidr }#"]
+serviceSubnets: ["#{ kubernetes.svc_cidr }#"]

--- a/template/config/talos/all/21-network.yaml.j2
+++ b/template/config/talos/all/21-network.yaml.j2
@@ -1,7 +1,8 @@
-machine:
-  network:
-    disableSearchDomain: true
-    nameservers:
-      #% for item in network.dns_servers %#
-      - #{ item }#
-      #% endfor %#
+apiVersion: v1alpha1
+kind: ResolverConfig
+nameservers:
+  #% for item in network.dns_servers %#
+  - address: #{ item }#
+  #% endfor %#
+searchDomains:
+  disableDefault: true

--- a/template/config/talos/all/22-time.yaml.j2
+++ b/template/config/talos/all/22-time.yaml.j2
@@ -1,7 +1,7 @@
-machine:
-  time:
-    disabled: false
-    servers:
-      #% for item in network.ntp_servers %#
-      - #{ item }#
-      #% endfor %#
+apiVersion: v1alpha1
+kind: TimeSyncConfig
+ntp:
+  servers:
+    #% for item in network.ntp_servers %#
+    - #{ item }#
+    #% endfor %#

--- a/template/config/talos/all/30-kubelet.yaml.j2
+++ b/template/config/talos/all/30-kubelet.yaml.j2
@@ -1,13 +1,16 @@
-machine:
-  kubelet:
-    extraConfig:
-      crashLoopBackOff:
-        maxContainerRestartPeriod: 60s
-      imageMaximumGCAge: 168h
-      maxParallelImagePulls: 3
-      serializeImagePulls: false
-      shutdownGracePeriod: 90s
-      shutdownGracePeriodCriticalPods: 60s
-    nodeIP:
-      validSubnets:
-        - #{ network.node_cidr }#
+apiVersion: v1alpha1
+kind: KubeletConfig
+config:
+  crashLoopBackOff:
+    maxContainerRestartPeriod: 60s
+  imageMaximumGCAge: 168h
+  maxParallelImagePulls: 3
+  serializeImagePulls: false
+  shutdownGracePeriod: 90s
+  shutdownGracePeriodCriticalPods: 60s
+---
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+nodeIP:
+  validSubnets:
+    - #{ network.node_cidr }#

--- a/template/config/talos/all/40-sysctls.yaml.j2
+++ b/template/config/talos/all/40-sysctls.yaml.j2
@@ -1,11 +1,12 @@
-machine:
-  sysctls:
-    fs.inotify.max_user_watches: "1048576" # Watchdog
-    fs.inotify.max_user_instances: "8192" # Watchdog
-    net.core.rmem_max: "7500000" # Cloudflared | QUIC
-    net.core.wmem_max: "7500000" # Cloudflared | QUIC
-    net.ipv4.neigh.default.gc_thresh1: "4096" # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh2: "8192" # Prevent ARP cache overflows
-    net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
-    net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
-    user.max_user_namespaces: "11255" # User Namespaces
+apiVersion: v1alpha1
+kind: SysctlConfig
+params:
+  fs.inotify.max_user_watches: "1048576" # Watchdog
+  fs.inotify.max_user_instances: "8192" # Watchdog
+  net.core.rmem_max: "7500000" # Cloudflared | QUIC
+  net.core.wmem_max: "7500000" # Cloudflared | QUIC
+  net.ipv4.neigh.default.gc_thresh1: "4096" # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh2: "8192" # Prevent ARP cache overflows
+  net.ipv4.neigh.default.gc_thresh3: "16384" # Prevent ARP cache overflows
+  net.ipv4.tcp_slow_start_after_idle: "0" # Preserve congestion window after idle
+  user.max_user_namespaces: "11255" # User Namespaces

--- a/template/config/talos/all/50-files.yaml.j2
+++ b/template/config/talos/all/50-files.yaml.j2
@@ -1,9 +1,8 @@
-machine:
-  files:
-    - op: create
-      path: /etc/cri/conf.d/20-customization.part
-      content: |
-        [plugins."io.containerd.cri.v1.images"]
-          discard_unpacked_layers = false
-        [plugins."io.containerd.cri.v1.runtime"]
-          device_ownership_from_security_context = true
+apiVersion: v1alpha1
+kind: CRICustomizationConfig
+name: containerd
+content: |
+  [plugins."io.containerd.cri.v1.images"]
+    discard_unpacked_layers = false
+  [plugins."io.containerd.cri.v1.runtime"]
+    device_ownership_from_security_context = true

--- a/template/config/talos/all/60-encryption.yaml.tpl.j2
+++ b/template/config/talos/all/60-encryption.yaml.tpl.j2
@@ -1,15 +1,20 @@
 {{- if .Node.Data.encryptDisk }}
 # Encrypt system disk with TPM
-machine:
-  systemDiskEncryption:
-    state:
-      provider: luks2
-      keys:
-        - slot: 0
-          tpm: {}
-    ephemeral:
-      provider: luks2
-      keys:
-        - slot: 0
-          tpm: {}
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: STATE
+encryption:
+  provider: luks2
+  keys:
+    - slot: 0
+      tpm: {}
+---
+apiVersion: v1alpha1
+kind: VolumeConfig
+name: EPHEMERAL
+encryption:
+  provider: luks2
+  keys:
+    - slot: 0
+      tpm: {}
 {{- end }}

--- a/template/config/talos/all/61-kernel-modules.yaml.tpl.j2
+++ b/template/config/talos/all/61-kernel-modules.yaml.tpl.j2
@@ -1,8 +1,6 @@
-{{- if .Node.Data.kernelModules }}
-machine:
-  kernel:
-    modules:
-      {{- range .Node.Data.kernelModules }}
-      - name: {{ . }}
-      {{- end }}
+{{- range .Node.Data.kernelModules }}
+---
+apiVersion: v1alpha1
+kind: KernelModuleConfig
+name: {{ . }}
 {{- end }}

--- a/template/config/talos/all/70-security.yaml.j2
+++ b/template/config/talos/all/70-security.yaml.j2
@@ -1,0 +1,7 @@
+# Talos 1.14 defaults to running kubelet and pods in a sandboxed PID/mount
+# namespace, which breaks workloads that rely on hostPID or host mounts
+# (node-exporter, GPU plugins, in-tree iSCSI). Set to true to opt in; on
+# encrypted disks expect a second reboot the first time it is enabled.
+apiVersion: v1alpha1
+kind: SecurityProfileConfig
+workloadIsolation: false

--- a/template/config/talos/all/71-filesystem.yaml.j2
+++ b/template/config/talos/all/71-filesystem.yaml.j2
@@ -1,0 +1,9 @@
+# Weekly online maintenance for XFS volumes: trim discards unused blocks
+# (SSDs, thin provisioning) and scrub checks filesystem metadata.
+apiVersion: v1alpha1
+kind: FilesystemTrimConfig
+interval: 168h0m0s
+---
+apiVersion: v1alpha1
+kind: FilesystemScrubConfig
+interval: 168h0m0s

--- a/template/config/talos/control-plane/00-cluster.yaml.j2
+++ b/template/config/talos/control-plane/00-cluster.yaml.j2
@@ -1,38 +1,62 @@
 cluster:
-  allowSchedulingOnControlPlanes: true
-  apiServer:
-    admissionControl:
-      $patch: delete
-    certSANs:
-      #% for item in cert_sans %#
-      - "#{ item }#"
-      #% endfor %#
-    extraArgs:
-      # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
-      enable-aggregator-routing: true
-  controllerManager:
-    extraArgs:
-      bind-address: 0.0.0.0
-  coreDNS:
-    disabled: true
   etcd:
     extraArgs:
       listen-metrics-urls: http://0.0.0.0:2381
     advertisedSubnets:
       - #{ network.node_cidr }#
-  proxy:
-    disabled: true
-  scheduler:
-    extraArgs:
-      bind-address: 0.0.0.0
-    config:
-      profiles:
-        - schedulerName: default-scheduler
-          pluginConfig:
-            - name: PodTopologySpread
-              args:
-                defaultingType: List
-                defaultConstraints:
-                  - maxSkew: 1
-                    topologyKey: kubernetes.io/hostname
-                    whenUnsatisfiable: ScheduleAnyway
+---
+# Allow scheduling on control-plane nodes
+apiVersion: v1alpha1
+kind: KubeNodeConfig
+taints:
+  node-role.kubernetes.io/control-plane:
+    $patch: delete
+---
+apiVersion: v1alpha1
+kind: KubeAdmissionControlConfig
+name: PodSecurity
+$patch: delete
+---
+apiVersion: v1alpha1
+kind: KubeAPIServerConfig
+certExtraSANs:
+  #% for item in cert_sans %#
+  - "#{ item }#"
+  #% endfor %#
+extraArgs:
+  # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
+  enable-aggregator-routing: "true"
+---
+apiVersion: v1alpha1
+kind: KubeControllerManagerConfig
+extraArgs:
+  bind-address: 0.0.0.0
+---
+apiVersion: v1alpha1
+kind: KubeCoreDNSConfig
+enabled: false
+---
+# Disable built-in CNI and kube-proxy to use Cilium
+apiVersion: v1alpha1
+kind: KubeFlannelCNIConfig
+$patch: delete
+---
+apiVersion: v1alpha1
+kind: KubeProxyConfig
+enabled: false
+---
+apiVersion: v1alpha1
+kind: KubeSchedulerConfig
+extraArgs:
+  bind-address: 0.0.0.0
+config:
+  profiles:
+    - schedulerName: default-scheduler
+      pluginConfig:
+        - name: PodTopologySpread
+          args:
+            defaultingType: List
+            defaultConstraints:
+              - maxSkew: 1
+                topologyKey: kubernetes.io/hostname
+                whenUnsatisfiable: ScheduleAnyway

--- a/template/config/talos/topf.yaml.j2
+++ b/template/config/talos/topf.yaml.j2
@@ -2,8 +2,8 @@
 clusterName: kubernetes
 clusterEndpoint: https://#{ kubernetes.api.addr }#:6443
 
-# renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.13.9
+# renovate: datasource=github-releases depName=siderolabs/talos
+talosVersion: v1.14.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.36.4
 


### PR DESCRIPTION
## Summary

- Bump `topf` to v0.6.0 and `talosctl` / `talosVersion` to 1.14.0.
- Talos 1.14 generates typed config documents and rejects the deprecated v1alpha1 fields the template patched (`machine.install`, `machine.kubelet`, `cluster.network`, `cluster.apiServer`, ...), so every patch under `template/config/talos` is rewritten to the new document kinds. Only `machine.certSANs`, `machine.features` and `cluster.etcd` remain v1alpha1.
- The auto-generated `KubeFlannelCNIConfig` and `PodSecurity` admission documents are removed with document-level `$patch: delete`; control-plane scheduling is a taint delete on `KubeNodeConfig`.
- Install disk is an `UnattendedInstallConfig` CEL selector. Device paths also match `disk.symlinks`, so `/dev/disk/by-id/...` keeps working; serials use `disk.serial`.
- Weekly `FilesystemTrimConfig` (the generator default, now explicit) and `FilesystemScrubConfig` for XFS volumes.
- Workload isolation (sandboxd) is explicitly disabled. Talos 1.14 turns it on for generated configs, which breaks `hostPID` / host-mount workloads (node-exporter, GPU plugins, in-tree iSCSI) and would silently switch on for existing users on their first 1.14 apply. The patch documents how to opt in.
- `ghcr.io/siderolabs/installer` is no longer published as of 1.14, which is why renovate never offered the update. The `talosVersion` annotation now tracks `siderolabs/talos` GitHub releases and the talos group matches that package only.
- `home-operations/talosctl-cluster-action` bumped to v0.2.2; v0.2 requires talosctl 1.14. Supersedes #2333.

## Upgrade notes for existing clusters

A 1.13 node rejects the new documents, so run `just talos upgrade-node <node>` before `just talos apply-node <node>`. `kubernetesVersion` stays at v1.36.4 (#2362 covers 1.37).

## Verification

- All eight valid fixtures: `just configure`, `oxfmt --check`, `just talos render`, `talosctl validate --mode metal` with topf 0.6.0 / talosctl 1.14.0.
- Serial and by-id install disk variants rendered and validated; an invalid CEL field fails validation, so the selectors are checked.
- Rendered documents inspected for each migrated setting; no deprecated fields remain.
- `renovate-config-validator` and `zizmor` pass.